### PR TITLE
docs(hands-on): problem and answer programs for all samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,15 @@ If you want a ready-made Phase 2 path, see `examples/README.md` and the website 
 - environment/disaster event sharing
 - webcam event sharing
 
+For workshop exercise versions with problem programs and reference solutions, see:
+- `examples/hands_on/README.md`
+- `examples/hands_on/huskylens2_mock/`
+- `examples/hands_on/webcam_littering_mock/`
+- `examples/hands_on/mobile_viewer/`
+- `examples/hands_on/phase1_ha_ssi_publisher/`
+- `examples/hands_on/phase2_environment_disaster/`
+- `examples/hands_on/phase2_webcam_event_sharing/`
+
 ## Directory Structure
 
 - `publisher/` : FastAPI-based Data Publisher

--- a/README_ja.md
+++ b/README_ja.md
@@ -215,6 +215,16 @@ docker compose -f infra/docker-compose.yml down
 - USBウェブカメライベント共有
 を参照してください。
 
+問題用プログラムと解答用プログラムを使うワークショップ形式にしたい場合は、次を参照してください。
+
+- `examples/hands_on/README.md`
+- `examples/hands_on/huskylens2_mock/`
+- `examples/hands_on/webcam_littering_mock/`
+- `examples/hands_on/mobile_viewer/`
+- `examples/hands_on/phase1_ha_ssi_publisher/`
+- `examples/hands_on/phase2_environment_disaster/`
+- `examples/hands_on/phase2_webcam_event_sharing/`
+
 ## ディレクトリ構成
 
 - `publisher/` : FastAPI ベース Data Publisher

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,24 @@
 # Examples
 
+## Hands-on sample programs
+
+- `examples/hands_on/README.md`
+  - overview of all exercise programs
+- `examples/hands_on/phase2_environment_disaster/problem_program.py`
+  - exercise version with `TODO`
+- `examples/hands_on/phase2_environment_disaster/answer_program.py`
+  - reference solution
+- `examples/hands_on/phase2_environment_disaster/README.md`
+  - step-by-step instructions for the exercise
+
+Other hands-on exercise directories:
+
+- `examples/hands_on/huskylens2_mock/`
+- `examples/hands_on/webcam_littering_mock/`
+- `examples/hands_on/mobile_viewer/`
+- `examples/hands_on/phase1_ha_ssi_publisher/`
+- `examples/hands_on/phase2_webcam_event_sharing/`
+
 ## Consent VC registration
 
 ```bash

--- a/examples/hands_on/README.md
+++ b/examples/hands_on/README.md
@@ -1,0 +1,27 @@
+# Hands-on Sample Programs
+
+This directory contains exercise programs for the hands-on materials.
+
+Each hands-on is organized in its own subdirectory and usually includes:
+
+- `problem_program.py`
+  - exercise version with `TODO`
+- `answer_program.py`
+  - reference solution
+- `README.md`
+  - what to run, in which order, and what output to expect
+
+## Available hands-on sample programs
+
+- `huskylens2_mock`
+  - generate a mock HUSKYLENS2 event file
+- `webcam_littering_mock`
+  - generate a mock USB webcam event file
+- `mobile_viewer`
+  - build and verify the smartphone access URL
+- `phase1_ha_ssi_publisher`
+  - send a Phase 1 temperature event to `/simulate/publish`
+- `phase2_environment_disaster`
+  - send a `flood_risk_high` event to `/simulate/publish`
+- `phase2_webcam_event_sharing`
+  - send a `possible_littering` event to `/simulate/publish`

--- a/examples/hands_on/common.py
+++ b/examples/hands_on/common.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Shared helpers for hands-on sample programs."""
+
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+from urllib import request
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def post_json(base_url: str, path: str, body: dict) -> dict:
+    payload = json.dumps(body).encode("utf-8")
+    req = request.Request(
+        base_url.rstrip("/") + path,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with request.urlopen(req, timeout=10) as resp:  # noqa: S310 - local training endpoint
+        return json.load(resp)
+
+
+def get_json(url: str) -> dict | list:
+    with request.urlopen(url, timeout=10) as resp:  # noqa: S310 - local training endpoint
+        return json.load(resp)
+
+
+def write_text(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def detect_lan_ip() -> str:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.connect(("8.8.8.8", 80))
+        return sock.getsockname()[0]
+    finally:
+        sock.close()

--- a/examples/hands_on/huskylens2_mock/README.md
+++ b/examples/hands_on/huskylens2_mock/README.md
@@ -1,0 +1,22 @@
+# HUSKYLENS2 Mock Hands-on Program
+
+## Goal
+
+Create a mock HUSKYLENS2 event file under `mediator-owner/raw_data/output`.
+
+## Files
+
+- `problem_program.py`
+- `answer_program.py`
+
+## Run
+
+```bash
+python3 examples/hands_on/huskylens2_mock/problem_program.py \
+  --output-dir mediator-owner/raw_data/output
+```
+
+Expected:
+
+- a file like `301_huskylens_mock_*.txt` is created
+- the file contains a JSON event for HUSKYLENS2 detection

--- a/examples/hands_on/huskylens2_mock/answer_program.py
+++ b/examples/hands_on/huskylens2_mock/answer_program.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.hands_on.common import write_text
+
+
+def build_event(camera_id: int) -> dict:
+    return {
+        "source": "huskylens2",
+        "camera_id": camera_id,
+        "event_type": "object_detected",
+        "label": "bottle",
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def build_output_path(output_dir: Path, camera_id: int) -> Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return output_dir / f"{camera_id}_huskylens_mock_{timestamp}.txt"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--camera-id", type=int, default=301)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    event = build_event(args.camera_id)
+    out = build_output_path(args.output_dir, args.camera_id)
+    write_text(out, json.dumps(event, ensure_ascii=False, indent=2) + "\n")
+    print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hands_on/huskylens2_mock/problem_program.py
+++ b/examples/hands_on/huskylens2_mock/problem_program.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.hands_on.common import write_text
+
+
+def build_event(camera_id: int) -> dict:
+    # TODO 1:
+    # Return a mock HUSKYLENS2 event dictionary.
+    #
+    # Required keys:
+    # - source: "huskylens2"
+    # - camera_id: function argument
+    # - event_type: "object_detected"
+    # - label: "bottle"
+    # - ts: current UTC ISO8601 string
+    raise NotImplementedError("TODO: implement build_event()")
+
+
+def build_output_path(output_dir: Path, camera_id: int) -> Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return output_dir / f"{camera_id}_huskylens_mock_{timestamp}.txt"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--camera-id", type=int, default=301)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    event = build_event(args.camera_id)
+    out = build_output_path(args.output_dir, args.camera_id)
+    write_text(out, json.dumps(event, ensure_ascii=False, indent=2) + "\n")
+    print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hands_on/mobile_viewer/README.md
+++ b/examples/hands_on/mobile_viewer/README.md
@@ -1,0 +1,15 @@
+# Mobile Viewer Hands-on Program
+
+## Goal
+
+Build the mobile viewer URL from the local LAN IP and optionally verify that the page is reachable.
+
+## Run
+
+```bash
+python3 examples/hands_on/mobile_viewer/problem_program.py
+```
+
+Expected:
+
+- prints a URL like `http://192.168.x.x:5173/mobile`

--- a/examples/hands_on/mobile_viewer/answer_program.py
+++ b/examples/hands_on/mobile_viewer/answer_program.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from urllib import request
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.hands_on.common import detect_lan_ip
+
+
+def build_mobile_url(host: str, port: int) -> str:
+    return f"http://{host}:{port}/mobile"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default=None)
+    parser.add_argument("--port", type=int, default=5173)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    host = args.host or detect_lan_ip()
+    url = build_mobile_url(host, args.port)
+    print(url)
+
+    if args.check:
+        with request.urlopen(url, timeout=5) as resp:  # noqa: S310 - local training endpoint
+            print(f"HTTP {resp.status}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hands_on/mobile_viewer/problem_program.py
+++ b/examples/hands_on/mobile_viewer/problem_program.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from urllib import request
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.hands_on.common import detect_lan_ip
+
+
+def build_mobile_url(host: str, port: int) -> str:
+    # TODO 1:
+    # Return the mobile viewer URL in the format:
+    # http://<host>:<port>/mobile
+    raise NotImplementedError("TODO: implement build_mobile_url()")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default=None)
+    parser.add_argument("--port", type=int, default=5173)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    host = args.host or detect_lan_ip()
+    url = build_mobile_url(host, args.port)
+    print(url)
+
+    if args.check:
+        with request.urlopen(url, timeout=5) as resp:  # noqa: S310 - local training endpoint
+            print(f"HTTP {resp.status}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hands_on/phase1_ha_ssi_publisher/README.md
+++ b/examples/hands_on/phase1_ha_ssi_publisher/README.md
@@ -1,0 +1,22 @@
+# Phase 1 HA x SSI Publisher Hands-on Program
+
+## Goal
+
+Send a temperature event to `/simulate/publish` and confirm an `allowed` result.
+
+## Files
+
+- `problem_program.py`
+- `answer_program.py`
+
+## Run
+
+```bash
+python3 examples/hands_on/phase1_ha_ssi_publisher/problem_program.py --purpose research
+```
+
+Expected:
+
+```json
+{"status":"allowed","dataset_id":"home/env/temperature"}
+```

--- a/examples/hands_on/phase1_ha_ssi_publisher/answer_program.py
+++ b/examples/hands_on/phase1_ha_ssi_publisher/answer_program.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.hands_on.common import load_json, post_json
+
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+DEFAULT_EVENT_FILE = BASE_DIR / "payload_temperature.json"
+
+
+def build_publish_request(payload: dict, purpose: str) -> dict:
+    return {
+        "topic": "homeassistant/state/sensor/temperature",
+        "payload": payload,
+        "purpose": purpose,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://localhost:8080")
+    parser.add_argument("--purpose", default="research")
+    parser.add_argument("--event-file", type=Path, default=DEFAULT_EVENT_FILE)
+    args = parser.parse_args()
+
+    payload = load_json(args.event_file)
+    body = build_publish_request(payload, args.purpose)
+    result = post_json(args.base_url, "/simulate/publish", body)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hands_on/phase1_ha_ssi_publisher/problem_program.py
+++ b/examples/hands_on/phase1_ha_ssi_publisher/problem_program.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.hands_on.common import load_json, post_json
+
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+DEFAULT_EVENT_FILE = BASE_DIR / "payload_temperature.json"
+
+
+def build_publish_request(payload: dict, purpose: str) -> dict:
+    # TODO 1:
+    # Return the body for /simulate/publish with:
+    # - topic: "homeassistant/state/sensor/temperature"
+    # - payload: loaded JSON
+    # - purpose: function argument
+    raise NotImplementedError("TODO: implement build_publish_request()")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://localhost:8080")
+    parser.add_argument("--purpose", default="research")
+    parser.add_argument("--event-file", type=Path, default=DEFAULT_EVENT_FILE)
+    args = parser.parse_args()
+
+    payload = load_json(args.event_file)
+    body = build_publish_request(payload, args.purpose)
+    result = post_json(args.base_url, "/simulate/publish", body)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hands_on/phase2_environment_disaster/README.md
+++ b/examples/hands_on/phase2_environment_disaster/README.md
@@ -1,0 +1,73 @@
+# Phase 2 Hands-on Sample Program
+
+This directory contains two small programs for the `Environment and Disaster Event Sharing` hands-on.
+
+## Files
+
+- `problem_program.py`
+  - exercise version with `TODO` sections
+- `answer_program.py`
+  - reference solution
+
+## Goal
+
+The programs send a `flood_risk_high` event to the local Publisher and check whether it becomes `allowed` or `denied` depending on `purpose`.
+
+## Related example files
+
+- `../../consent_flood_risk_high.json`
+- `../../payload_flood_risk_high.json`
+
+## Recommended hands-on flow
+
+1. Start the publisher stack:
+
+```bash
+docker compose -f infra/docker-compose.yml up --build -d
+```
+
+2. Register the consent:
+
+```bash
+curl -X POST http://localhost:8080/consents \
+  -H 'Content-Type: application/json' \
+  -d @examples/consent_flood_risk_high.json
+```
+
+3. Read `problem_program.py` and complete the `TODO` sections.
+
+4. Run the program:
+
+```bash
+python3 examples/hands_on/phase2_environment_disaster/problem_program.py --purpose disaster_response
+```
+
+Expected result:
+
+```json
+{"status":"allowed","dataset_id":"home/event/flood_risk_high"}
+```
+
+5. Try a denied case:
+
+```bash
+python3 examples/hands_on/phase2_environment_disaster/problem_program.py --purpose advertising
+```
+
+Expected result:
+
+```json
+{"status":"denied","dataset_id":"home/event/flood_risk_high","reason":"no_matching_consent"}
+```
+
+6. If needed, compare with the reference solution:
+
+```bash
+python3 examples/hands_on/phase2_environment_disaster/answer_program.py --purpose disaster_response
+```
+
+## What learners should understand
+
+- how a Phase 2 event is represented as JSON
+- how `topic`, `payload`, and `purpose` are combined for `/simulate/publish`
+- how the same event becomes `allowed` or `denied` depending on Consent VC

--- a/examples/hands_on/phase2_environment_disaster/answer_program.py
+++ b/examples/hands_on/phase2_environment_disaster/answer_program.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Reference solution for the Phase 2 environment/disaster event-sharing hands-on."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from urllib import request
+
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+DEFAULT_EVENT_FILE = BASE_DIR / "payload_flood_risk_high.json"
+SIMULATE_PUBLISH_PATH = "/simulate/publish"
+
+
+def load_event_payload(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def build_publish_request(payload: dict, purpose: str) -> dict:
+    return {
+        "topic": "homeassistant/event/flood_risk_high",
+        "payload": payload,
+        "purpose": purpose,
+    }
+
+
+def post_json(base_url: str, path: str, body: dict) -> dict:
+    payload = json.dumps(body).encode("utf-8")
+    req = request.Request(
+        base_url.rstrip("/") + path,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with request.urlopen(req, timeout=10) as resp:  # noqa: S310 - local training endpoint
+        return json.load(resp)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Phase 2 hands-on answer: send flood_risk_high to the Publisher."
+    )
+    parser.add_argument("--base-url", default="http://localhost:8080")
+    parser.add_argument("--purpose", default="disaster_response")
+    parser.add_argument("--event-file", type=Path, default=DEFAULT_EVENT_FILE)
+    args = parser.parse_args()
+
+    event_payload = load_event_payload(args.event_file)
+    request_body = build_publish_request(event_payload, args.purpose)
+    result = post_json(args.base_url, SIMULATE_PUBLISH_PATH, request_body)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hands_on/phase2_environment_disaster/problem_program.py
+++ b/examples/hands_on/phase2_environment_disaster/problem_program.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Exercise program for the Phase 2 environment/disaster event-sharing hands-on."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from urllib import request
+
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+DEFAULT_EVENT_FILE = BASE_DIR / "payload_flood_risk_high.json"
+SIMULATE_PUBLISH_PATH = "/simulate/publish"
+
+
+def load_event_payload(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def build_publish_request(payload: dict, purpose: str) -> dict:
+    # TODO 1:
+    # Return the request body expected by POST /simulate/publish.
+    #
+    # It must include:
+    # - topic: "homeassistant/event/flood_risk_high"
+    # - payload: the loaded JSON event
+    # - purpose: the function argument
+    #
+    # Example output:
+    # {
+    #   "topic": "homeassistant/event/flood_risk_high",
+    #   "payload": {...},
+    #   "purpose": "disaster_response"
+    # }
+    raise NotImplementedError("TODO: implement build_publish_request()")
+
+
+def post_json(base_url: str, path: str, body: dict) -> dict:
+    payload = json.dumps(body).encode("utf-8")
+    req = request.Request(
+        base_url.rstrip("/") + path,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with request.urlopen(req, timeout=10) as resp:  # noqa: S310 - local training endpoint
+        return json.load(resp)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Phase 2 hands-on exercise: send flood_risk_high to the Publisher."
+    )
+    parser.add_argument("--base-url", default="http://localhost:8080")
+    parser.add_argument("--purpose", default="disaster_response")
+    parser.add_argument("--event-file", type=Path, default=DEFAULT_EVENT_FILE)
+    args = parser.parse_args()
+
+    event_payload = load_event_payload(args.event_file)
+    request_body = build_publish_request(event_payload, args.purpose)
+    result = post_json(args.base_url, SIMULATE_PUBLISH_PATH, request_body)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hands_on/phase2_webcam_event_sharing/README.md
+++ b/examples/hands_on/phase2_webcam_event_sharing/README.md
@@ -1,0 +1,17 @@
+# Phase 2 Webcam Event Sharing Hands-on Program
+
+## Goal
+
+Send a `possible_littering` event to `/simulate/publish` and compare `allowed` and `denied` by purpose.
+
+## Run
+
+```bash
+python3 examples/hands_on/phase2_webcam_event_sharing/problem_program.py --purpose community_cleaning
+```
+
+Expected:
+
+```json
+{"status":"allowed","dataset_id":"home/event/possible_littering"}
+```

--- a/examples/hands_on/phase2_webcam_event_sharing/answer_program.py
+++ b/examples/hands_on/phase2_webcam_event_sharing/answer_program.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.hands_on.common import load_json, post_json
+
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+DEFAULT_EVENT_FILE = BASE_DIR / "payload_possible_littering.json"
+
+
+def build_publish_request(payload: dict, purpose: str) -> dict:
+    return {
+        "topic": "homeassistant/event/possible_littering",
+        "payload": payload,
+        "purpose": purpose,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://localhost:8080")
+    parser.add_argument("--purpose", default="community_cleaning")
+    parser.add_argument("--event-file", type=Path, default=DEFAULT_EVENT_FILE)
+    args = parser.parse_args()
+
+    payload = load_json(args.event_file)
+    body = build_publish_request(payload, args.purpose)
+    result = post_json(args.base_url, "/simulate/publish", body)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hands_on/phase2_webcam_event_sharing/problem_program.py
+++ b/examples/hands_on/phase2_webcam_event_sharing/problem_program.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.hands_on.common import load_json, post_json
+
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+DEFAULT_EVENT_FILE = BASE_DIR / "payload_possible_littering.json"
+
+
+def build_publish_request(payload: dict, purpose: str) -> dict:
+    # TODO 1:
+    # Return the body for /simulate/publish with:
+    # - topic: "homeassistant/event/possible_littering"
+    # - payload: loaded JSON
+    # - purpose: function argument
+    raise NotImplementedError("TODO: implement build_publish_request()")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://localhost:8080")
+    parser.add_argument("--purpose", default="community_cleaning")
+    parser.add_argument("--event-file", type=Path, default=DEFAULT_EVENT_FILE)
+    args = parser.parse_args()
+
+    payload = load_json(args.event_file)
+    body = build_publish_request(payload, args.purpose)
+    result = post_json(args.base_url, "/simulate/publish", body)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hands_on/webcam_littering_mock/README.md
+++ b/examples/hands_on/webcam_littering_mock/README.md
@@ -1,0 +1,17 @@
+# USB Webcam Littering Mock Hands-on Program
+
+## Goal
+
+Create a mock webcam event file for `possible_littering`.
+
+## Run
+
+```bash
+python3 examples/hands_on/webcam_littering_mock/problem_program.py \
+  --output-dir mediator-owner/raw_data/output
+```
+
+Expected:
+
+- a file like `401_webcam_event_*.txt` is created
+- the file contains a `possible_littering` event

--- a/examples/hands_on/webcam_littering_mock/answer_program.py
+++ b/examples/hands_on/webcam_littering_mock/answer_program.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.hands_on.common import write_text
+
+
+def build_event(camera_id: int) -> dict:
+    return {
+        "source": "usb_webcam",
+        "camera_id": camera_id,
+        "event_type": "possible_littering",
+        "object_class": "bottle",
+        "confidence": 0.87,
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def build_output_path(output_dir: Path, camera_id: int) -> Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return output_dir / f"{camera_id}_webcam_event_{timestamp}.txt"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--camera-id", type=int, default=401)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    event = build_event(args.camera_id)
+    out = build_output_path(args.output_dir, args.camera_id)
+    write_text(out, json.dumps(event, ensure_ascii=False, indent=2) + "\n")
+    print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hands_on/webcam_littering_mock/problem_program.py
+++ b/examples/hands_on/webcam_littering_mock/problem_program.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.hands_on.common import write_text
+
+
+def build_event(camera_id: int) -> dict:
+    # TODO 1:
+    # Return a mock webcam event with:
+    # - source: "usb_webcam"
+    # - camera_id: function argument
+    # - event_type: "possible_littering"
+    # - object_class: "bottle"
+    # - confidence: 0.87
+    # - ts: current UTC ISO8601 string
+    raise NotImplementedError("TODO: implement build_event()")
+
+
+def build_output_path(output_dir: Path, camera_id: int) -> Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return output_dir / f"{camera_id}_webcam_event_{timestamp}.txt"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--camera-id", type=int, default=401)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    event = build_event(args.camera_id)
+    out = build_output_path(args.output_dir, args.camera_id)
+    write_text(out, json.dumps(event, ensure_ascii=False, indent=2) + "\n")
+    print(out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add \`problem_program.py\` / \`answer_program.py\` pairs and READMEs for each hands-on sample (\`webcam_littering_mock\`, \`phase2_webcam_event_sharing\`, and the Phase 1/2/3 samples referenced from the iw3ip.github.io hands-on pages)

Third of a 4-PR split. **Depends on PR2** — please merge #7 first.

## Test plan
- [ ] Each \`answer_program.py\` runs end-to-end against the publisher and produces the expected \`allowed\` / \`denied\` sequence
- [ ] Each \`problem_program.py\` fails informatively until the student completes the marked section

🤖 Generated with [Claude Code](https://claude.com/claude-code)