### PR TITLE
feat(ssi): OID4VCI issuer and OID4VP verifier for SSI wallet hands-on (Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ site/
 # Python cache
 __pycache__/
 *.pyc
+.venv-ssi/

--- a/audit/models.py
+++ b/audit/models.py
@@ -13,3 +13,6 @@ class AuditLogRecord:
     reason: str
     message_hash: str
     raw_topic: str
+    holder_did: str | None = None
+    vc_hash: str | None = None
+    presentation_verified: str | None = None

--- a/audit/repository.py
+++ b/audit/repository.py
@@ -6,6 +6,13 @@ from pathlib import Path
 from audit.models import AuditLogRecord
 
 
+PHASE2_COLUMNS = [
+    ("holder_did", "TEXT"),
+    ("vc_hash", "TEXT"),
+    ("presentation_verified", "TEXT"),
+]
+
+
 class SQLiteAuditRepository:
     def __init__(self, db_path: str) -> None:
         self._db_path = Path(db_path)
@@ -34,6 +41,10 @@ class SQLiteAuditRepository:
                 )
                 """
             )
+            existing = {row["name"] for row in conn.execute("PRAGMA table_info(audit_log)")}
+            for col, sqltype in PHASE2_COLUMNS:
+                if col not in existing:
+                    conn.execute(f"ALTER TABLE audit_log ADD COLUMN {col} {sqltype}")
             conn.commit()
 
     def write(self, record: AuditLogRecord) -> None:
@@ -42,8 +53,9 @@ class SQLiteAuditRepository:
                 """
                 INSERT INTO audit_log (
                     ts, action, subject_did, dataset_id, purpose,
-                    reason, message_hash, raw_topic
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    reason, message_hash, raw_topic,
+                    holder_did, vc_hash, presentation_verified
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     record.ts,
@@ -54,6 +66,9 @@ class SQLiteAuditRepository:
                     record.reason,
                     record.message_hash,
                     record.raw_topic,
+                    record.holder_did,
+                    record.vc_hash,
+                    record.presentation_verified,
                 ),
             )
             conn.commit()
@@ -63,7 +78,8 @@ class SQLiteAuditRepository:
             rows = conn.execute(
                 """
                 SELECT id, ts, action, subject_did, dataset_id, purpose,
-                       reason, message_hash, raw_topic
+                       reason, message_hash, raw_topic,
+                       holder_did, vc_hash, presentation_verified
                 FROM audit_log
                 ORDER BY id DESC
                 LIMIT ?

--- a/examples/ssi_wallet/README.md
+++ b/examples/ssi_wallet/README.md
@@ -1,0 +1,9 @@
+# Presentation Definitions for the SSI wallet hands-on
+
+These files are served by the publisher at
+`GET /verifier/presentation-definitions/{id}` and consumed by the
+Sphereon-forked wallet when it handles an OID4VP Authorization Request.
+
+The custom `iw3ip_dataset_id` top-level field lets the publisher map
+`GET /verifier/request?dataset_id=...` to a specific definition without
+hard-coding the mapping in Python.

--- a/examples/ssi_wallet/consent-flood-risk-high.json
+++ b/examples/ssi_wallet/consent-flood-risk-high.json
@@ -1,0 +1,43 @@
+{
+  "id": "consent-flood-risk-high",
+  "name": "Consent VC for home/env/flood_risk_high",
+  "purpose": "Verify the wallet holds a ConsentVC allowing high-flood-risk event sharing.",
+  "iw3ip_dataset_id": "home/env/flood_risk_high",
+  "input_descriptors": [
+    {
+      "id": "consent_vc_flood_risk_high",
+      "name": "ConsentVC (flood_risk_high)",
+      "format": {
+        "vc+sd-jwt": {
+          "sd-jwt_alg_values": ["ES256"],
+          "kb-jwt_alg_values": ["ES256"]
+        }
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": ["$.vct"],
+            "filter": {
+              "type": "string",
+              "const": "https://iw3ip.example/credentials/ConsentVC/v1"
+            }
+          },
+          {
+            "path": ["$.dataset_id"],
+            "filter": {
+              "type": "string",
+              "const": "home/env/flood_risk_high"
+            }
+          },
+          {
+            "path": ["$.allowed_purposes"],
+            "filter": { "type": "array" }
+          },
+          {
+            "path": ["$.subject_id"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/ssi_wallet/consent-person-detected.json
+++ b/examples/ssi_wallet/consent-person-detected.json
@@ -1,0 +1,43 @@
+{
+  "id": "consent-person-detected",
+  "name": "Consent VC for home/env/person_detected",
+  "purpose": "Verify the wallet holds a ConsentVC allowing person-detected event sharing.",
+  "iw3ip_dataset_id": "home/env/person_detected",
+  "input_descriptors": [
+    {
+      "id": "consent_vc_person_detected",
+      "name": "ConsentVC (person_detected)",
+      "format": {
+        "vc+sd-jwt": {
+          "sd-jwt_alg_values": ["ES256"],
+          "kb-jwt_alg_values": ["ES256"]
+        }
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": ["$.vct"],
+            "filter": {
+              "type": "string",
+              "const": "https://iw3ip.example/credentials/ConsentVC/v1"
+            }
+          },
+          {
+            "path": ["$.dataset_id"],
+            "filter": {
+              "type": "string",
+              "const": "home/env/person_detected"
+            }
+          },
+          {
+            "path": ["$.allowed_purposes"],
+            "filter": { "type": "array" }
+          },
+          {
+            "path": ["$.subject_id"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/ssi_wallet/consent-temperature.json
+++ b/examples/ssi_wallet/consent-temperature.json
@@ -1,0 +1,43 @@
+{
+  "id": "consent-temperature",
+  "name": "Consent VC for home/env/temperature",
+  "purpose": "Verify the wallet holds a ConsentVC allowing temperature data sharing.",
+  "iw3ip_dataset_id": "home/env/temperature",
+  "input_descriptors": [
+    {
+      "id": "consent_vc_temperature",
+      "name": "ConsentVC (temperature)",
+      "format": {
+        "vc+sd-jwt": {
+          "sd-jwt_alg_values": ["ES256"],
+          "kb-jwt_alg_values": ["ES256"]
+        }
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": ["$.vct"],
+            "filter": {
+              "type": "string",
+              "const": "https://iw3ip.example/credentials/ConsentVC/v1"
+            }
+          },
+          {
+            "path": ["$.dataset_id"],
+            "filter": {
+              "type": "string",
+              "const": "home/env/temperature"
+            }
+          },
+          {
+            "path": ["$.allowed_purposes"],
+            "filter": { "type": "array" }
+          },
+          {
+            "path": ["$.subject_id"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -23,10 +23,25 @@ services:
       PUBLISHER_ID: publisher-001
       AUDIT_DB_PATH: /data/audit.db
       CONSENT_STORE_PATH: /data/consents.json
+      SSI_ISSUER_BASE_URL: http://publisher:8080
+      SSI_ISSUER_KEY_PATH: /data/issuer_key.jwk.json
+      SSI_PEX_SIDECAR_URL: http://verifier-sidecar:7000
+      SSI_PRESENTATION_DEFS_DIR: /app/examples/ssi_wallet
     ports:
       - "8080:8080"
     volumes:
       - publisher_data:/data
+
+  verifier-sidecar:
+    build:
+      context: ../ssi/verifier-sidecar
+      dockerfile: Dockerfile
+    container_name: iw3ip-verifier-sidecar
+    profiles: ["ssi-wallet"]
+    environment:
+      PORT: "7000"
+    ports:
+      - "7000:7000"
 
   nodered:
     image: nodered/node-red:latest

--- a/publisher/Dockerfile
+++ b/publisher/Dockerfile
@@ -7,9 +7,18 @@ COPY publisher ./publisher
 COPY schemas ./schemas
 COPY policy ./policy
 COPY audit ./audit
+COPY examples ./examples
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir fastapi uvicorn pydantic pydantic-settings httpx paho-mqtt
+    pip install --no-cache-dir \
+        fastapi \
+        uvicorn \
+        'pydantic>=2' \
+        pydantic-settings \
+        'httpx>=0.28' \
+        paho-mqtt \
+        'cryptography>=42' \
+        python-multipart
 
 EXPOSE 8080
 

--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -12,10 +12,17 @@ from publisher.app.models import SimulatePublishRequest
 from publisher.app.mqtt_subscriber import MQTTSubscriber
 from publisher.app.pipeline import MessageProcessor
 from publisher.app.platform_client import PlatformClient
+from publisher.app.ssi import issuer_routes, verifier_routes
+from publisher.app.ssi.config import SSISettings
+from publisher.app.ssi.keys import IssuerKeyStore
+from publisher.app.ssi.pex_client import PEXSidecarClient
+from publisher.app.ssi.presentation_defs import PresentationDefinitionStore
+from publisher.app.ssi.state import SSIStateStore
 
 
 configure_logging()
 settings = Settings()
+ssi_settings = SSISettings()
 
 consent_store = ConsentStore(settings.consent_store_path)
 audit_repo = SQLiteAuditRepository(settings.audit_db_path)
@@ -40,6 +47,34 @@ mqtt_subscriber = MQTTSubscriber(
 
 app = FastAPI(title="IW3IP Data Publisher", version="0.1.0")
 app.state.ingested = []
+
+ssi_keys = IssuerKeyStore(ssi_settings.issuer_key_path)
+ssi_state = SSIStateStore(
+    offer_ttl=ssi_settings.offer_ttl_seconds,
+    response_ttl=ssi_settings.response_ttl_seconds,
+)
+ssi_definitions = PresentationDefinitionStore(ssi_settings.presentation_defs_dir)
+ssi_pex_client = PEXSidecarClient(ssi_settings.pex_sidecar_url)
+
+app.include_router(
+    issuer_routes.build_router(
+        issuer_routes.IssuerDeps(
+            settings=ssi_settings, keys=ssi_keys, state=ssi_state
+        )
+    )
+)
+app.include_router(
+    verifier_routes.build_router(
+        verifier_routes.VerifierDeps(
+            settings=ssi_settings,
+            keys=ssi_keys,
+            state=ssi_state,
+            definitions=ssi_definitions,
+            audit_repo=audit_repo,
+            pex_client=ssi_pex_client,
+        )
+    )
+)
 
 
 @app.on_event("startup")

--- a/publisher/app/ssi/__init__.py
+++ b/publisher/app/ssi/__init__.py
@@ -1,0 +1,1 @@
+"""OID4VCI issuer and OID4VP verifier components."""

--- a/publisher/app/ssi/config.py
+++ b/publisher/app/ssi/config.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class SSISettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="SSI_", extra="ignore")
+
+    enabled: bool = False
+    issuer_base_url: str = "http://localhost:8080"
+    issuer_key_path: str = "/data/issuer_key.jwk.json"
+    issuer_id: str = "iw3ip-publisher-issuer"
+    credential_ttl_days: int = 365
+    offer_ttl_seconds: int = 600
+    pex_sidecar_url: str = "http://verifier-sidecar:7000"
+    presentation_defs_dir: str = "/app/examples/ssi_wallet"
+    response_ttl_seconds: int = 600

--- a/publisher/app/ssi/did_jwk.py
+++ b/publisher/app/ssi/did_jwk.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import base64
+import json
+
+
+def _b64u(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def did_jwk_from_public_jwk(public_jwk: dict) -> str:
+    """Encode a did:jwk identifier from a public JWK.
+
+    Per https://github.com/quartzjer/did-jwk/blob/main/spec.md — the method-specific
+    id is base64url(JSON(public_jwk)) with canonical key order.
+    """
+    canonical = json.dumps(public_jwk, sort_keys=True, separators=(",", ":"))
+    return "did:jwk:" + _b64u(canonical.encode("utf-8"))
+
+
+def public_jwk_from_did_jwk(did: str) -> dict:
+    if not did.startswith("did:jwk:"):
+        raise ValueError("not a did:jwk")
+    encoded = did[len("did:jwk:") :]
+    padded = encoded + "=" * (-len(encoded) % 4)
+    return json.loads(base64.urlsafe_b64decode(padded).decode("utf-8"))

--- a/publisher/app/ssi/html.py
+++ b/publisher/app/ssi/html.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import html as _html
+
+
+_QR_PAGE = """<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <title>{title}</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; padding: 2rem; max-width: 720px; margin: 0 auto; }}
+    #qr {{ margin: 1rem 0; }}
+    pre {{ background: #f4f4f4; padding: 1rem; overflow-x: auto; font-size: 0.85rem; }}
+    a.deeplink {{ display: inline-block; margin-top: 0.5rem; }}
+  </style>
+</head>
+<body>
+  <h1>{title}</h1>
+  <p>{subtitle}</p>
+  <div id="qr"></div>
+  <p><a class="deeplink" href="{deeplink}">{deeplink_label}</a></p>
+  <details open><summary>payload</summary><pre>{payload_json}</pre></details>
+  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
+  <script>
+    QRCode.toCanvas(document.getElementById('qr'), {deeplink_js}, {{ width: 320 }});
+  </script>
+</body>
+</html>
+"""
+
+
+def render_qr_page(
+    *,
+    title: str,
+    subtitle: str,
+    deeplink: str,
+    deeplink_label: str,
+    payload_json: str,
+) -> str:
+    import json as _json
+
+    return _QR_PAGE.format(
+        title=_html.escape(title),
+        subtitle=_html.escape(subtitle),
+        deeplink=_html.escape(deeplink, quote=True),
+        deeplink_label=_html.escape(deeplink_label),
+        payload_json=_html.escape(payload_json),
+        deeplink_js=_json.dumps(deeplink),
+    )

--- a/publisher/app/ssi/issuer_routes.py
+++ b/publisher/app/ssi/issuer_routes.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import json
+import time
+import urllib.parse
+from dataclasses import dataclass
+
+from fastapi import APIRouter, Form, Header, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from publisher.app.ssi.config import SSISettings
+from publisher.app.ssi.did_jwk import did_jwk_from_public_jwk, public_jwk_from_did_jwk
+from publisher.app.ssi.html import render_qr_page
+from publisher.app.ssi.keys import IssuerKeyStore
+from publisher.app.ssi.sdjwt import issue_sd_jwt_vc
+from publisher.app.ssi.state import SSIStateStore
+
+
+CREDENTIAL_CONFIG_ID = "ConsentVC"
+VCT = "https://iw3ip.example/credentials/ConsentVC/v1"
+DEEPLINK_SCHEME = "openid-credential-offer://"
+
+DEFAULT_ALLOWED_PURPOSES = {
+    "home/env/temperature": ["research", "planning"],
+    "home/env/person_detected": ["safety", "research"],
+    "home/env/flood_risk_high": ["safety", "emergency_planning"],
+    "home/env/possible_littering": ["community_awareness", "planning"],
+    "home/energy/power": ["research", "planning"],
+}
+
+
+@dataclass
+class IssuerDeps:
+    settings: SSISettings
+    keys: IssuerKeyStore
+    state: SSIStateStore
+
+
+def _issuer_did(keys: IssuerKeyStore) -> str:
+    return did_jwk_from_public_jwk(keys.public_jwk)
+
+
+def _credential_offer(settings: SSISettings, pre_auth_code: str) -> dict:
+    return {
+        "credential_issuer": settings.issuer_base_url,
+        "credential_configuration_ids": [CREDENTIAL_CONFIG_ID],
+        "grants": {
+            "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+                "pre-authorized_code": pre_auth_code,
+            }
+        },
+    }
+
+
+def _credential_issuer_metadata(settings: SSISettings, keys: IssuerKeyStore) -> dict:
+    issuer_did = _issuer_did(keys)
+    return {
+        "credential_issuer": settings.issuer_base_url,
+        "token_endpoint": f"{settings.issuer_base_url}/issuer/token",
+        "credential_endpoint": f"{settings.issuer_base_url}/issuer/credential",
+        "authorization_servers": [settings.issuer_base_url],
+        "credential_configurations_supported": {
+            CREDENTIAL_CONFIG_ID: {
+                "format": "vc+sd-jwt",
+                "vct": VCT,
+                "scope": "ConsentVC",
+                "cryptographic_binding_methods_supported": ["jwk", "did:jwk"],
+                "credential_signing_alg_values_supported": ["ES256"],
+                "proof_types_supported": {
+                    "jwt": {"proof_signing_alg_values_supported": ["ES256"]}
+                },
+                "display": [
+                    {"name": "IW3IP Consent Credential", "locale": "en"},
+                    {"name": "IW3IP 同意クレデンシャル", "locale": "ja"},
+                ],
+                "claims": {
+                    "dataset_id": {"display": [{"name": "Dataset ID"}]},
+                    "purpose": {"display": [{"name": "Purpose"}]},
+                    "subject_id": {
+                        "display": [{"name": "Subject"}],
+                        "mandatory": False,
+                    },
+                    "iw3ip_issuer": {"display": [{"name": "Issuer"}]},
+                },
+            }
+        },
+        "issuer": issuer_did,
+        "jwks": {"keys": [keys.public_jwk]},
+    }
+
+
+def _parse_proof_jwt(proof_jwt: str, expected_nonce: str, expected_aud: str) -> dict:
+    from publisher.app.ssi.sdjwt import _b64u_decode, _es256_verify
+
+    try:
+        h_b64, p_b64, s_b64 = proof_jwt.split(".")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"malformed proof JWT: {exc}")
+
+    header = json.loads(_b64u_decode(h_b64))
+    payload = json.loads(_b64u_decode(p_b64))
+    signature = _b64u_decode(s_b64)
+
+    if header.get("typ") != "openid4vci-proof+jwt":
+        raise HTTPException(status_code=400, detail="proof typ must be openid4vci-proof+jwt")
+
+    holder_jwk = header.get("jwk")
+    holder_kid = header.get("kid")
+    if not holder_jwk and holder_kid and holder_kid.startswith("did:jwk:"):
+        holder_jwk = public_jwk_from_did_jwk(holder_kid.split("#")[0])
+    if not holder_jwk:
+        raise HTTPException(status_code=400, detail="proof header missing jwk/kid")
+
+    signing_input = (h_b64 + "." + p_b64).encode("ascii")
+    if not _es256_verify(holder_jwk, signing_input, signature):
+        raise HTTPException(status_code=400, detail="proof signature invalid")
+
+    if payload.get("nonce") != expected_nonce:
+        raise HTTPException(status_code=400, detail="proof nonce mismatch")
+    if payload.get("aud") not in (expected_aud, expected_aud.rstrip("/")):
+        raise HTTPException(status_code=400, detail="proof aud mismatch")
+
+    return holder_jwk
+
+
+def build_router(deps: IssuerDeps) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/.well-known/openid-credential-issuer")
+    def issuer_metadata() -> dict:
+        return _credential_issuer_metadata(deps.settings, deps.keys)
+
+    @router.get("/.well-known/oauth-authorization-server")
+    def as_metadata() -> dict:
+        base = deps.settings.issuer_base_url
+        return {
+            "issuer": base,
+            "token_endpoint": f"{base}/issuer/token",
+            "grant_types_supported": [
+                "urn:ietf:params:oauth:grant-type:pre-authorized_code"
+            ],
+            "token_endpoint_auth_methods_supported": ["none"],
+            "response_types_supported": ["token"],
+        }
+
+    @router.get("/issuer/offer")
+    def issuer_offer(
+        request: Request,
+        type: str = Query("ConsentVC", alias="type"),
+        dataset_id: str = Query(...),
+        purpose: str = Query(...),
+    ):
+        if type != "ConsentVC":
+            raise HTTPException(status_code=400, detail="only ConsentVC is supported")
+
+        allowed = DEFAULT_ALLOWED_PURPOSES.get(dataset_id, [purpose])
+        offer = deps.state.create_offer(
+            credential_config_id=CREDENTIAL_CONFIG_ID,
+            dataset_id=dataset_id,
+            purpose=purpose,
+            allowed_purposes=allowed,
+        )
+        co = _credential_offer(deps.settings, offer.pre_authorized_code)
+        deeplink = (
+            DEEPLINK_SCHEME
+            + "?credential_offer="
+            + urllib.parse.quote(json.dumps(co, separators=(",", ":")))
+        )
+
+        accept = request.headers.get("accept", "")
+        if "application/json" in accept or request.query_params.get("format") == "json":
+            return JSONResponse(
+                {
+                    "credential_offer": co,
+                    "deeplink": deeplink,
+                    "pre_authorized_code": offer.pre_authorized_code,
+                    "dataset_id": dataset_id,
+                    "purpose": purpose,
+                    "allowed_purposes": allowed,
+                }
+            )
+
+        html = render_qr_page(
+            title="IW3IP Consent VC を発行",
+            subtitle=f"dataset_id={dataset_id} / purpose={purpose}",
+            deeplink=deeplink,
+            deeplink_label="ウォレットで開く",
+            payload_json=json.dumps(co, indent=2, ensure_ascii=False),
+        )
+        return HTMLResponse(html)
+
+    @router.post("/issuer/token")
+    def issuer_token(
+        grant_type: str = Form(...),
+        pre_authorized_code: str = Form(..., alias="pre-authorized_code"),
+    ):
+        if grant_type != "urn:ietf:params:oauth:grant-type:pre-authorized_code":
+            raise HTTPException(status_code=400, detail="unsupported_grant_type")
+        offer = deps.state.consume_offer(pre_authorized_code)
+        if not offer:
+            raise HTTPException(status_code=400, detail="invalid_grant")
+        token = deps.state.issue_token(offer)
+        return {
+            "access_token": token.token,
+            "token_type": "Bearer",
+            "expires_in": deps.settings.offer_ttl_seconds,
+            "c_nonce": token.c_nonce,
+            "c_nonce_expires_in": deps.settings.offer_ttl_seconds,
+        }
+
+    @router.post("/issuer/credential")
+    def issuer_credential(
+        body: dict,
+        authorization: str | None = Header(default=None),
+    ):
+        if not authorization or not authorization.lower().startswith("bearer "):
+            raise HTTPException(status_code=401, detail="missing bearer token")
+        token_str = authorization.split(" ", 1)[1]
+        token = deps.state.get_token(token_str)
+        if not token:
+            raise HTTPException(status_code=401, detail="invalid_token")
+        offer = deps.state.get_offer_for_token(token)
+        if not offer:
+            raise HTTPException(status_code=400, detail="no_offer_for_token")
+
+        if body.get("format") != "vc+sd-jwt":
+            raise HTTPException(status_code=400, detail="only vc+sd-jwt supported")
+        if body.get("vct") and body["vct"] != VCT:
+            raise HTTPException(status_code=400, detail=f"unknown vct: {body['vct']}")
+
+        proof = body.get("proof") or {}
+        if proof.get("proof_type") != "jwt" or "jwt" not in proof:
+            raise HTTPException(status_code=400, detail="proof_type=jwt required")
+
+        holder_jwk = _parse_proof_jwt(
+            proof["jwt"],
+            expected_nonce=token.c_nonce,
+            expected_aud=deps.settings.issuer_base_url,
+        )
+
+        now = int(time.time())
+        exp = now + deps.settings.credential_ttl_days * 86400
+        issuer_did = _issuer_did(deps.keys)
+        holder_did = did_jwk_from_public_jwk(holder_jwk)
+
+        vc = issue_sd_jwt_vc(
+            issuer_private_jwk=deps.keys.private_jwk,
+            issuer_did=issuer_did,
+            vct=VCT,
+            plain_claims={
+                "dataset_id": offer.dataset_id,
+                "allowed_purposes": offer.allowed_purposes,
+                "iw3ip_issuer": deps.settings.issuer_id,
+            },
+            sd_claims={
+                "subject_id": holder_did,
+            },
+            holder_cnf_jwk=holder_jwk,
+            iat=now,
+            exp=exp,
+        )
+        return {"credential": vc.compact, "format": "vc+sd-jwt"}
+
+    return router

--- a/publisher/app/ssi/keys.py
+++ b/publisher/app/ssi/keys.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.backends import default_backend
+
+
+logger = logging.getLogger(__name__)
+
+
+def _b64u(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _int_to_b64u(value: int, length: int) -> str:
+    return _b64u(value.to_bytes(length, "big"))
+
+
+def private_key_to_jwk(pk: ec.EllipticCurvePrivateKey) -> dict:
+    numbers = pk.private_numbers()
+    pub = numbers.public_numbers
+    return {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": _int_to_b64u(pub.x, 32),
+        "y": _int_to_b64u(pub.y, 32),
+        "d": _int_to_b64u(numbers.private_value, 32),
+    }
+
+
+def public_jwk_from_private_jwk(jwk: dict) -> dict:
+    return {k: v for k, v in jwk.items() if k in {"kty", "crv", "x", "y"}}
+
+
+def jwk_to_private_key(jwk: dict) -> ec.EllipticCurvePrivateKey:
+    d = int.from_bytes(base64.urlsafe_b64decode(jwk["d"] + "=="), "big")
+    return ec.derive_private_key(d, ec.SECP256R1(), default_backend())
+
+
+def jwk_to_public_key(jwk: dict) -> ec.EllipticCurvePublicKey:
+    x = int.from_bytes(base64.urlsafe_b64decode(jwk["x"] + "=="), "big")
+    y = int.from_bytes(base64.urlsafe_b64decode(jwk["y"] + "=="), "big")
+    return ec.EllipticCurvePublicKey.from_encoded_point(
+        ec.SECP256R1(),
+        b"\x04" + x.to_bytes(32, "big") + y.to_bytes(32, "big"),
+    )
+
+
+class IssuerKeyStore:
+    def __init__(self, key_path: str) -> None:
+        self._path = Path(key_path)
+        self._jwk: dict | None = None
+
+    def load_or_create(self) -> dict:
+        if self._jwk is not None:
+            return self._jwk
+        if self._path.exists():
+            self._jwk = json.loads(self._path.read_text(encoding="utf-8"))
+            return self._jwk
+
+        logger.info("issuer key not found; generating new P-256 key at %s", self._path)
+        pk = ec.generate_private_key(ec.SECP256R1(), default_backend())
+        jwk = private_key_to_jwk(pk)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(json.dumps(jwk, indent=2), encoding="utf-8")
+        self._path.chmod(0o600)
+        self._jwk = jwk
+        return jwk
+
+    @property
+    def private_jwk(self) -> dict:
+        return self.load_or_create()
+
+    @property
+    def public_jwk(self) -> dict:
+        return public_jwk_from_private_jwk(self.load_or_create())

--- a/publisher/app/ssi/pex_client.py
+++ b/publisher/app/ssi/pex_client.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import httpx
+
+
+class PEXSidecarClient:
+    def __init__(self, base_url: str, timeout: float = 10.0) -> None:
+        self._base = base_url.rstrip("/")
+        self._timeout = timeout
+
+    def verify(
+        self,
+        *,
+        presentation_definition: dict,
+        vp_token: str,
+        presentation_submission: dict,
+        issuer_public_jwk: dict,
+        expected_nonce: str,
+        expected_aud: str,
+    ) -> dict:
+        """Ask the sidecar to run @sphereon/pex against the submission.
+
+        Returns {"verified": bool, "reason": str, "claims": dict, "holder_did": str | None}.
+        Network failures raise; caller decides fallback behavior.
+        """
+        payload = {
+            "presentation_definition": presentation_definition,
+            "vp_token": vp_token,
+            "presentation_submission": presentation_submission,
+            "issuer_public_jwk": issuer_public_jwk,
+            "expected_nonce": expected_nonce,
+            "expected_aud": expected_aud,
+        }
+        with httpx.Client(timeout=self._timeout) as client:
+            resp = client.post(f"{self._base}/verify", json=payload)
+            resp.raise_for_status()
+            return resp.json()

--- a/publisher/app/ssi/presentation_defs.py
+++ b/publisher/app/ssi/presentation_defs.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class PresentationDefinitionStore:
+    def __init__(self, directory: str) -> None:
+        self._dir = Path(directory)
+
+    def get(self, pd_id: str) -> dict | None:
+        path = self._dir / f"{pd_id}.json"
+        if not path.exists():
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def list_ids(self) -> list[str]:
+        if not self._dir.exists():
+            return []
+        return sorted(p.stem for p in self._dir.glob("*.json"))
+
+    def find_for_dataset(self, dataset_id: str) -> tuple[str, dict] | None:
+        for pd_id in self.list_ids():
+            pd = self.get(pd_id)
+            if not pd:
+                continue
+            if pd.get("iw3ip_dataset_id") == dataset_id:
+                return pd_id, pd
+        return None

--- a/publisher/app/ssi/sdjwt.py
+++ b/publisher/app/ssi/sdjwt.py
@@ -1,0 +1,149 @@
+"""Minimal SD-JWT VC issuance and verification.
+
+Implements a subset of draft-ietf-oauth-sd-jwt-vc / draft-ietf-oauth-selective-disclosure-jwt
+sufficient for the IW3IP hands-on: ES256 signing, salted disclosures, `_sd` array,
+`cnf` holder binding, optional KB-JWT.
+
+This is NOT a full spec implementation: it only supports flat SD claims (no nested
+SD, no decoy digests, no array SD), and always uses SHA-256. It is intended for
+educational and interop-sanity use against the Sphereon wallet, not production.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+from dataclasses import dataclass
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+
+from publisher.app.ssi.keys import jwk_to_private_key, jwk_to_public_key
+
+
+def _b64u(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64u_decode(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def _json_bytes(obj) -> bytes:
+    return json.dumps(obj, separators=(",", ":"), sort_keys=False).encode("utf-8")
+
+
+def _sha256_b64u(data: bytes) -> str:
+    return _b64u(hashlib.sha256(data).digest())
+
+
+def _es256_sign(private_jwk: dict, signing_input: bytes) -> bytes:
+    pk = jwk_to_private_key(private_jwk)
+    der = pk.sign(signing_input, ec.ECDSA(hashes.SHA256()))
+    r, s = utils.decode_dss_signature(der)
+    return r.to_bytes(32, "big") + s.to_bytes(32, "big")
+
+
+def _es256_verify(public_jwk: dict, signing_input: bytes, signature: bytes) -> bool:
+    if len(signature) != 64:
+        return False
+    r = int.from_bytes(signature[:32], "big")
+    s = int.from_bytes(signature[32:], "big")
+    der = utils.encode_dss_signature(r, s)
+    pub = jwk_to_public_key(public_jwk)
+    try:
+        pub.verify(der, signing_input, ec.ECDSA(hashes.SHA256()))
+        return True
+    except Exception:
+        return False
+
+
+@dataclass
+class SDJWTCredential:
+    compact: str
+    disclosures: list[str]
+    issuer_jwt: str
+
+
+def make_disclosure(name: str, value) -> tuple[str, str]:
+    """Return (disclosure_b64u, sd_digest)."""
+    salt = _b64u(secrets.token_bytes(16))
+    arr = [salt, name, value]
+    encoded = _b64u(_json_bytes(arr))
+    digest = _sha256_b64u(encoded.encode("ascii"))
+    return encoded, digest
+
+
+def issue_sd_jwt_vc(
+    *,
+    issuer_private_jwk: dict,
+    issuer_did: str,
+    vct: str,
+    plain_claims: dict,
+    sd_claims: dict,
+    holder_cnf_jwk: dict,
+    iat: int,
+    exp: int,
+) -> SDJWTCredential:
+    disclosures: list[str] = []
+    sd_digests: list[str] = []
+    for name, value in sd_claims.items():
+        enc, digest = make_disclosure(name, value)
+        disclosures.append(enc)
+        sd_digests.append(digest)
+
+    body = {
+        "iss": issuer_did,
+        "vct": vct,
+        "iat": iat,
+        "exp": exp,
+        "cnf": {"jwk": holder_cnf_jwk},
+        "_sd_alg": "sha-256",
+        **plain_claims,
+    }
+    if sd_digests:
+        body["_sd"] = sd_digests
+
+    header = {"alg": "ES256", "typ": "vc+sd-jwt", "kid": issuer_did + "#0"}
+    signing_input = _b64u(_json_bytes(header)).encode("ascii") + b"." + _b64u(_json_bytes(body)).encode("ascii")
+    sig = _es256_sign(issuer_private_jwk, signing_input)
+    jwt = signing_input.decode("ascii") + "." + _b64u(sig)
+    compact = jwt + "~" + "~".join(disclosures) + ("~" if disclosures else "")
+    return SDJWTCredential(compact=compact, disclosures=disclosures, issuer_jwt=jwt)
+
+
+def parse_sd_jwt_vc(compact: str) -> tuple[dict, dict, bytes, list[str], str | None]:
+    """Return (header, payload, signature, disclosures, kb_jwt_or_none)."""
+    parts = compact.split("~")
+    jwt = parts[0]
+    rest = parts[1:]
+    kb = rest[-1] if rest and rest[-1] else None
+    disclosures = [d for d in rest[:-1] if d]
+
+    h_b64, p_b64, s_b64 = jwt.split(".")
+    header = json.loads(_b64u_decode(h_b64))
+    payload = json.loads(_b64u_decode(p_b64))
+    signature = _b64u_decode(s_b64)
+    return header, payload, signature, disclosures, kb
+
+
+def verify_sd_jwt_vc(compact: str, issuer_public_jwk: dict) -> dict:
+    header, payload, sig, disclosures, _kb = parse_sd_jwt_vc(compact)
+    jwt = compact.split("~")[0]
+    signing_input = ".".join(jwt.split(".")[:2]).encode("ascii")
+    if not _es256_verify(issuer_public_jwk, signing_input, sig):
+        raise ValueError("issuer signature invalid")
+
+    disclosed: dict = {}
+    sd_set = set(payload.get("_sd", []))
+    for d in disclosures:
+        digest = _sha256_b64u(d.encode("ascii"))
+        if digest not in sd_set:
+            raise ValueError(f"disclosure not referenced by _sd: {digest}")
+        salt, name, value = json.loads(_b64u_decode(d))
+        disclosed[name] = value
+
+    merged = {k: v for k, v in payload.items() if k not in {"_sd", "_sd_alg"}}
+    merged.update(disclosed)
+    return merged

--- a/publisher/app/ssi/state.py
+++ b/publisher/app/ssi/state.py
@@ -1,0 +1,145 @@
+"""In-memory state for OID4VCI offers and OID4VP requests.
+
+Hands-on scale only; not suitable for multi-worker deployments. State is lost
+on restart — re-issue the VC from the wallet flow. For the target scenario
+(one publisher container, one wallet), this is adequate.
+"""
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Offer:
+    pre_authorized_code: str
+    credential_config_id: str
+    dataset_id: str
+    purpose: str
+    allowed_purposes: list[str]
+    created_at: float
+    consumed: bool = False
+
+
+@dataclass
+class AccessToken:
+    token: str
+    pre_authorized_code: str
+    c_nonce: str
+    created_at: float
+
+
+@dataclass
+class VerificationRequest:
+    request_id: str
+    state: str
+    nonce: str
+    presentation_definition_id: str
+    dataset_id: str
+    purpose: str
+    created_at: float
+    result: dict | None = None
+
+
+class SSIStateStore:
+    def __init__(self, offer_ttl: int = 600, response_ttl: int = 600) -> None:
+        self._lock = threading.Lock()
+        self._offers: dict[str, Offer] = {}
+        self._tokens: dict[str, AccessToken] = {}
+        self._requests: dict[str, VerificationRequest] = {}
+        self._offer_ttl = offer_ttl
+        self._response_ttl = response_ttl
+
+    # ---- OID4VCI ----
+
+    def create_offer(
+        self,
+        credential_config_id: str,
+        dataset_id: str,
+        purpose: str,
+        allowed_purposes: list[str],
+    ) -> Offer:
+        code = secrets.token_urlsafe(24)
+        offer = Offer(
+            pre_authorized_code=code,
+            credential_config_id=credential_config_id,
+            dataset_id=dataset_id,
+            purpose=purpose,
+            allowed_purposes=allowed_purposes,
+            created_at=time.time(),
+        )
+        with self._lock:
+            self._offers[code] = offer
+        return offer
+
+    def consume_offer(self, code: str) -> Offer | None:
+        with self._lock:
+            offer = self._offers.get(code)
+            if not offer or offer.consumed:
+                return None
+            if time.time() - offer.created_at > self._offer_ttl:
+                return None
+            offer.consumed = True
+            return offer
+
+    def issue_token(self, offer: Offer) -> AccessToken:
+        token = AccessToken(
+            token=secrets.token_urlsafe(32),
+            pre_authorized_code=offer.pre_authorized_code,
+            c_nonce=secrets.token_urlsafe(16),
+            created_at=time.time(),
+        )
+        with self._lock:
+            self._tokens[token.token] = token
+        return token
+
+    def get_token(self, token: str) -> AccessToken | None:
+        with self._lock:
+            t = self._tokens.get(token)
+            if not t:
+                return None
+            if time.time() - t.created_at > self._offer_ttl:
+                return None
+            return t
+
+    def get_offer_for_token(self, token: AccessToken) -> Offer | None:
+        with self._lock:
+            return self._offers.get(token.pre_authorized_code)
+
+    # ---- OID4VP ----
+
+    def create_verification_request(
+        self,
+        presentation_definition_id: str,
+        dataset_id: str,
+        purpose: str,
+    ) -> VerificationRequest:
+        req = VerificationRequest(
+            request_id=secrets.token_urlsafe(16),
+            state=secrets.token_urlsafe(16),
+            nonce=secrets.token_urlsafe(16),
+            presentation_definition_id=presentation_definition_id,
+            dataset_id=dataset_id,
+            purpose=purpose,
+            created_at=time.time(),
+        )
+        with self._lock:
+            self._requests[req.state] = req
+        return req
+
+    def find_verification_request(self, state: str) -> VerificationRequest | None:
+        with self._lock:
+            req = self._requests.get(state)
+            if not req:
+                return None
+            if time.time() - req.created_at > self._response_ttl:
+                return None
+            return req
+
+    def record_verification_result(self, state: str, result: dict) -> None:
+        with self._lock:
+            req = self._requests.get(state)
+            if req:
+                req.result = result

--- a/publisher/app/ssi/verifier_routes.py
+++ b/publisher/app/ssi/verifier_routes.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+import urllib.parse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import httpx
+from fastapi import APIRouter, Form, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from audit.models import AuditLogRecord
+from audit.repository import SQLiteAuditRepository
+from publisher.app.ssi.config import SSISettings
+from publisher.app.ssi.html import render_qr_page
+from publisher.app.ssi.keys import IssuerKeyStore
+from publisher.app.ssi.pex_client import PEXSidecarClient
+from publisher.app.ssi.presentation_defs import PresentationDefinitionStore
+from publisher.app.ssi.sdjwt import parse_sd_jwt_vc, verify_sd_jwt_vc
+from publisher.app.ssi.state import SSIStateStore
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VerifierDeps:
+    settings: SSISettings
+    keys: IssuerKeyStore
+    state: SSIStateStore
+    definitions: PresentationDefinitionStore
+    audit_repo: SQLiteAuditRepository
+    pex_client: PEXSidecarClient
+
+
+def _vc_hash(vp_token: str) -> str:
+    compact = vp_token.split("~")[0]
+    return "sha256:" + hashlib.sha256(compact.encode("utf-8")).hexdigest()
+
+
+def _write_audit(
+    audit_repo: SQLiteAuditRepository,
+    *,
+    action: str,
+    reason: str,
+    dataset_id: str,
+    purpose: str,
+    holder_did: str | None,
+    vc_hash: str | None,
+    verified: str,
+) -> None:
+    audit_repo.write(
+        AuditLogRecord(
+            ts=datetime.now(timezone.utc).isoformat(),
+            action=action,
+            subject_did=holder_did or "unknown",
+            dataset_id=dataset_id,
+            purpose=purpose,
+            reason=reason,
+            message_hash="",
+            raw_topic="oid4vp/response",
+            holder_did=holder_did,
+            vc_hash=vc_hash,
+            presentation_verified=verified,
+        )
+    )
+
+
+def _local_pex_fallback(
+    pd: dict,
+    vp_token: str,
+    issuer_public_jwk: dict,
+    dataset_id: str,
+    purpose: str,
+) -> dict:
+    """Fallback verification when the Node sidecar is unreachable.
+
+    Only honors a minimal subset of PEX v2: for each input descriptor, each
+    constraint field is treated as a JSONPath-like dotted path into the
+    disclosed VC claims, with optional `filter.const` equality.
+    """
+    claims = verify_sd_jwt_vc(vp_token, issuer_public_jwk)
+    for descriptor in pd.get("input_descriptors", []):
+        for field in descriptor.get("constraints", {}).get("fields", []):
+            paths = field.get("path", [])
+            filt = field.get("filter") or {}
+            const = filt.get("const")
+            got = None
+            for p in paths:
+                if not p.startswith("$."):
+                    continue
+                parts = p[2:].split(".")
+                cur = claims
+                ok = True
+                for part in parts:
+                    if isinstance(cur, dict) and part in cur:
+                        cur = cur[part]
+                    else:
+                        ok = False
+                        break
+                if ok:
+                    got = cur
+                    break
+            if const is not None and got != const:
+                return {
+                    "verified": False,
+                    "reason": f"field_mismatch:{paths[0] if paths else '?'}",
+                    "claims": claims,
+                    "holder_did": None,
+                }
+    # enforce request-time purpose/dataset
+    if claims.get("dataset_id") != dataset_id:
+        return {"verified": False, "reason": "dataset_mismatch", "claims": claims, "holder_did": None}
+    allowed = claims.get("allowed_purposes", [])
+    if purpose not in allowed:
+        return {"verified": False, "reason": "purpose_mismatch", "claims": claims, "holder_did": None}
+    cnf = claims.get("cnf", {}).get("jwk")
+    holder_did = None
+    if cnf:
+        from publisher.app.ssi.did_jwk import did_jwk_from_public_jwk
+
+        holder_did = did_jwk_from_public_jwk(cnf)
+    return {"verified": True, "reason": "ok", "claims": claims, "holder_did": holder_did}
+
+
+def build_router(deps: VerifierDeps) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/verifier/presentation-definitions/{pd_id}")
+    def get_presentation_definition(pd_id: str) -> dict:
+        pd = deps.definitions.get(pd_id)
+        if not pd:
+            raise HTTPException(status_code=404, detail="presentation_definition_not_found")
+        return pd
+
+    @router.get("/verifier/request")
+    def verifier_request(
+        request: Request,
+        dataset_id: str = Query(...),
+        purpose: str = Query(...),
+    ):
+        match = deps.definitions.find_for_dataset(dataset_id)
+        if not match:
+            raise HTTPException(status_code=404, detail="no_presentation_definition_for_dataset")
+        pd_id, pd = match
+        req = deps.state.create_verification_request(pd_id, dataset_id, purpose)
+
+        authz = {
+            "response_type": "vp_token",
+            "response_mode": "direct_post",
+            "client_id": deps.settings.issuer_base_url,
+            "response_uri": f"{deps.settings.issuer_base_url}/verifier/response",
+            "presentation_definition": pd,
+            "nonce": req.nonce,
+            "state": req.state,
+        }
+        deeplink = "openid4vp://?" + urllib.parse.urlencode(
+            {
+                "client_id": authz["client_id"],
+                "request": json.dumps(authz, separators=(",", ":")),
+            }
+        )
+
+        accept = request.headers.get("accept", "")
+        if "application/json" in accept or request.query_params.get("format") == "json":
+            return JSONResponse({
+                "authorization_request": authz,
+                "deeplink": deeplink,
+                "state": req.state,
+                "nonce": req.nonce,
+            })
+
+        html = render_qr_page(
+            title="IW3IP Consent VC を提示",
+            subtitle=f"dataset_id={dataset_id} / purpose={purpose}",
+            deeplink=deeplink,
+            deeplink_label="ウォレットで開く",
+            payload_json=json.dumps(authz, indent=2, ensure_ascii=False),
+        )
+        return HTMLResponse(html)
+
+    @router.post("/verifier/response")
+    def verifier_response(
+        vp_token: str = Form(...),
+        presentation_submission: str = Form(...),
+        state: str = Form(...),
+    ):
+        req = deps.state.find_verification_request(state)
+        if not req:
+            raise HTTPException(status_code=400, detail="unknown_or_expired_state")
+
+        pd = deps.definitions.get(req.presentation_definition_id)
+        if not pd:
+            raise HTTPException(status_code=500, detail="presentation_definition_missing")
+
+        submission = json.loads(presentation_submission)
+        vc_hash_value = _vc_hash(vp_token)
+
+        try:
+            result = deps.pex_client.verify(
+                presentation_definition=pd,
+                vp_token=vp_token,
+                presentation_submission=submission,
+                issuer_public_jwk=deps.keys.public_jwk,
+                expected_nonce=req.nonce,
+                expected_aud=deps.settings.issuer_base_url,
+            )
+        except (httpx.HTTPError, httpx.InvalidURL) as exc:
+            logger.warning("PEX sidecar unreachable (%s); using local fallback", exc)
+            try:
+                result = _local_pex_fallback(
+                    pd, vp_token, deps.keys.public_jwk, req.dataset_id, req.purpose
+                )
+            except Exception as fb_exc:  # noqa: BLE001
+                result = {"verified": False, "reason": f"verify_error:{fb_exc}", "claims": {}, "holder_did": None}
+
+        verified = bool(result.get("verified"))
+        reason = result.get("reason") or ("ok" if verified else "verification_failed")
+        holder_did = result.get("holder_did")
+
+        # Phase 2 purpose check (belt-and-braces against PEX)
+        claims = result.get("claims") or {}
+        if verified:
+            if claims.get("dataset_id") not in (None, req.dataset_id):
+                verified = False
+                reason = "dataset_mismatch"
+            else:
+                allowed = claims.get("allowed_purposes")
+                if allowed is not None and req.purpose not in allowed:
+                    verified = False
+                    reason = "purpose_mismatch"
+
+        deps.state.record_verification_result(
+            state, {"verified": verified, "reason": reason}
+        )
+        _write_audit(
+            deps.audit_repo,
+            action="allow" if verified else "deny",
+            reason=reason,
+            dataset_id=req.dataset_id,
+            purpose=req.purpose,
+            holder_did=holder_did,
+            vc_hash=vc_hash_value,
+            verified="allow" if verified else "deny",
+        )
+        if verified:
+            return {"status": "allowed", "dataset_id": req.dataset_id}
+        return {"status": "denied", "dataset_id": req.dataset_id, "reason": reason}
+
+    @router.get("/verifier/status")
+    def verifier_status(state: str = Query(...)) -> dict:
+        req = deps.state.find_verification_request(state)
+        if not req:
+            raise HTTPException(status_code=404, detail="unknown_or_expired_state")
+        return {
+            "state": state,
+            "result": req.result,
+            "dataset_id": req.dataset_id,
+            "purpose": req.purpose,
+        }
+
+    return router

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
   "pydantic-settings>=2.10.0",
   "httpx>=0.28.0",
   "paho-mqtt>=2.1.0",
+  "cryptography>=42",
+  "python-multipart>=0.0.9",
 ]
 
 [dependency-groups]

--- a/ssi/verifier-sidecar/Dockerfile
+++ b/ssi/verifier-sidecar/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --omit=dev
+
+COPY src ./src
+
+EXPOSE 7000
+
+CMD ["node", "src/server.js"]

--- a/ssi/verifier-sidecar/README.md
+++ b/ssi/verifier-sidecar/README.md
@@ -1,0 +1,18 @@
+# iw3ip-verifier-sidecar
+
+Node.js sidecar that runs SD-JWT VC signature verification and
+`@sphereon/pex` Presentation Exchange v2 evaluation on behalf of the
+Python publisher.
+
+The publisher posts to `POST /verify` with the VP token and submission
+received from the wallet, plus the presentation definition and issuer
+public JWK; the sidecar returns `{verified, reason, claims, holder_did}`.
+
+Run standalone:
+
+```bash
+npm install
+PORT=7000 npm start
+```
+
+In Compose, it is started via the `ssi-wallet` profile.

--- a/ssi/verifier-sidecar/package.json
+++ b/ssi/verifier-sidecar/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "iw3ip-verifier-sidecar",
+  "version": "0.1.0",
+  "private": true,
+  "description": "OID4VP presentation verification sidecar using @sphereon/pex and SD-JWT VC.",
+  "type": "module",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "@sphereon/pex": "^5.0.0",
+    "express": "^4.21.0",
+    "jose": "^5.9.6"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/ssi/verifier-sidecar/src/server.js
+++ b/ssi/verifier-sidecar/src/server.js
@@ -1,0 +1,100 @@
+import express from "express";
+import { PEX } from "@sphereon/pex";
+import { importJWK, jwtVerify } from "jose";
+
+const PORT = Number(process.env.PORT || 7000);
+const app = express();
+app.use(express.json({ limit: "2mb" }));
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "iw3ip-verifier-sidecar" });
+});
+
+function b64uDecode(s) {
+  const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
+  return Buffer.from(s.replace(/-/g, "+").replace(/_/g, "/") + pad, "base64");
+}
+
+async function verifySdJwtVc(compact, issuerPublicJwk) {
+  const parts = compact.split("~");
+  const jwt = parts[0];
+  const rest = parts.slice(1);
+  const kb = rest.length > 0 && rest[rest.length - 1] !== "" ? rest[rest.length - 1] : null;
+  const disclosures = rest.slice(0, rest.length - 1).filter((d) => d !== "");
+
+  const key = await importJWK(issuerPublicJwk, "ES256");
+  const { payload, protectedHeader } = await jwtVerify(jwt, key, { algorithms: ["ES256"] });
+  const payloadObj = typeof payload === "object" ? payload : JSON.parse(Buffer.from(payload).toString("utf-8"));
+
+  const sdSet = new Set(payloadObj._sd || []);
+  const disclosed = {};
+  for (const d of disclosures) {
+    const digest = Buffer.from(
+      await crypto.subtle.digest("SHA-256", Buffer.from(d, "ascii"))
+    );
+    const digestB64u = digest.toString("base64").replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+    if (!sdSet.has(digestB64u)) {
+      throw new Error("disclosure not referenced by _sd");
+    }
+    const arr = JSON.parse(b64uDecode(d).toString("utf-8"));
+    disclosed[arr[1]] = arr[2];
+  }
+  const merged = { ...payloadObj };
+  delete merged._sd;
+  delete merged._sd_alg;
+  Object.assign(merged, disclosed);
+  return { claims: merged, header: protectedHeader, kb };
+}
+
+app.post("/verify", async (req, res) => {
+  try {
+    const {
+      presentation_definition,
+      vp_token,
+      presentation_submission,
+      issuer_public_jwk,
+      expected_nonce,
+      expected_aud,
+    } = req.body || {};
+
+    if (!presentation_definition || !vp_token || !presentation_submission) {
+      return res.status(400).json({ verified: false, reason: "missing_fields" });
+    }
+
+    const { claims } = await verifySdJwtVc(vp_token, issuer_public_jwk);
+
+    const pex = new PEX();
+    const selectResult = pex.evaluateCredentials(presentation_definition, [
+      { ...claims, vct: claims.vct },
+    ]);
+    if (selectResult.errors && selectResult.errors.length > 0) {
+      return res.json({
+        verified: false,
+        reason: "pex_evaluate_error:" + selectResult.errors.map((e) => e.message || e.tag).join(","),
+        claims,
+        holder_did: null,
+      });
+    }
+
+    let holderDid = null;
+    const cnfJwk = claims.cnf && claims.cnf.jwk;
+    if (cnfJwk) {
+      const canonical = JSON.stringify(cnfJwk, Object.keys(cnfJwk).sort());
+      holderDid = "did:jwk:" + Buffer.from(canonical, "utf-8").toString("base64")
+        .replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+    }
+
+    return res.json({ verified: true, reason: "ok", claims, holder_did: holderDid });
+  } catch (err) {
+    return res.status(200).json({
+      verified: false,
+      reason: "verify_error:" + (err && err.message ? err.message : String(err)),
+      claims: {},
+      holder_did: null,
+    });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`[iw3ip-verifier-sidecar] listening on :${PORT}`);
+});

--- a/tests/test_ssi_wallet_flow.py
+++ b/tests/test_ssi_wallet_flow.py
@@ -1,0 +1,226 @@
+"""End-to-end OID4VCI issuance + OID4VP presentation using the local
+PEX fallback (no Node sidecar running).
+
+Simulates a Sphereon-style wallet: generate a P-256 holder key, do the
+pre-authorized_code flow against /issuer/token + /issuer/credential, then
+post the resulting SD-JWT VC back to /verifier/response for the challenge
+created by /verifier/request.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from publisher.app.ssi.did_jwk import did_jwk_from_public_jwk
+from publisher.app.ssi.keys import private_key_to_jwk, public_jwk_from_private_jwk
+from publisher.app.ssi.sdjwt import _es256_sign, _b64u, _json_bytes
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setenv("SSI_ISSUER_KEY_PATH", str(tmp_path / "issuer_key.jwk.json"))
+    monkeypatch.setenv("SSI_PRESENTATION_DEFS_DIR", str(repo_root / "examples" / "ssi_wallet"))
+    monkeypatch.setenv("SSI_ISSUER_BASE_URL", "http://testserver")
+    monkeypatch.setenv("AUDIT_DB_PATH", str(tmp_path / "audit.db"))
+    monkeypatch.setenv("CONSENT_STORE_PATH", str(tmp_path / "consents.json"))
+    monkeypatch.setenv("PLATFORM_API_URL", "http://testserver/platform/ingest")
+    monkeypatch.setenv("MQTT_BROKER_HOST", "localhost")
+    monkeypatch.setenv("MQTT_TOPICS", "")
+
+    # Force the sidecar to be unreachable so we exercise the local fallback.
+    monkeypatch.setenv("SSI_PEX_SIDECAR_URL", "http://127.0.0.1:1")
+
+    import importlib
+    import publisher.app.main as pm
+    importlib.reload(pm)
+
+    with patch("publisher.app.mqtt_subscriber.MQTTSubscriber.start", lambda self: None), \
+         patch("publisher.app.mqtt_subscriber.MQTTSubscriber.stop", lambda self: None):
+        from fastapi.testclient import TestClient
+        with TestClient(pm.app) as tc:
+            yield tc
+
+
+def _make_holder_key():
+    pk = ec.generate_private_key(ec.SECP256R1())
+    jwk = private_key_to_jwk(pk)
+    pub = public_jwk_from_private_jwk(jwk)
+    did = did_jwk_from_public_jwk(pub)
+    return jwk, pub, did
+
+
+def _make_proof_jwt(holder_jwk_private, holder_jwk_public, nonce, aud):
+    header = {"alg": "ES256", "typ": "openid4vci-proof+jwt", "jwk": holder_jwk_public}
+    payload = {"nonce": nonce, "aud": aud, "iat": int(time.time())}
+    h = _b64u(_json_bytes(header))
+    p = _b64u(_json_bytes(payload))
+    sig = _es256_sign(holder_jwk_private, (h + "." + p).encode("ascii"))
+    return h + "." + p + "." + _b64u(sig)
+
+
+def _make_presentation_submission(pd_id: str, input_desc_id: str) -> dict:
+    return {
+        "id": "sub-" + pd_id,
+        "definition_id": pd_id,
+        "descriptor_map": [
+            {"id": input_desc_id, "format": "vc+sd-jwt", "path": "$"}
+        ],
+    }
+
+
+def test_health_and_well_known(client):
+    assert client.get("/health").json()["status"] == "ok"
+    meta = client.get("/.well-known/openid-credential-issuer").json()
+    assert meta["credential_endpoint"].endswith("/issuer/credential")
+    assert "ConsentVC" in meta["credential_configurations_supported"]
+
+
+def test_presentation_definition_lookup(client):
+    pd = client.get("/verifier/presentation-definitions/consent-temperature").json()
+    assert pd["iw3ip_dataset_id"] == "home/env/temperature"
+    assert client.get("/verifier/presentation-definitions/unknown").status_code == 404
+
+
+def test_full_issuance_and_verification_allow(client):
+    holder_priv, holder_pub, holder_did = _make_holder_key()
+
+    # 1. offer (JSON form)
+    offer = client.get(
+        "/issuer/offer",
+        params={"type": "ConsentVC", "dataset_id": "home/env/temperature", "purpose": "research"},
+        headers={"accept": "application/json"},
+    ).json()
+    pre_auth = offer["pre_authorized_code"]
+
+    # 2. token
+    token = client.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": pre_auth,
+        },
+    ).json()
+    assert "access_token" in token
+    assert "c_nonce" in token
+
+    # 3. credential (with proof JWT)
+    proof = _make_proof_jwt(holder_priv, holder_pub, token["c_nonce"], "http://testserver")
+    cred = client.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+        json={
+            "format": "vc+sd-jwt",
+            "vct": "https://iw3ip.example/credentials/ConsentVC/v1",
+            "proof": {"proof_type": "jwt", "jwt": proof},
+        },
+    ).json()
+    vp_token = cred["credential"]
+    assert vp_token.count("~") >= 1
+
+    # 4. verifier request
+    req = client.get(
+        "/verifier/request",
+        params={"dataset_id": "home/env/temperature", "purpose": "research"},
+        headers={"accept": "application/json"},
+    ).json()
+    state = req["state"]
+
+    # 5. verifier response (ALLOW path)
+    submission = _make_presentation_submission("consent-temperature", "consent_vc_temperature")
+    r = client.post(
+        "/verifier/response",
+        data={
+            "vp_token": vp_token,
+            "presentation_submission": json.dumps(submission),
+            "state": state,
+        },
+    )
+    body = r.json()
+    assert r.status_code == 200, body
+    assert body["status"] == "allowed", body
+    assert body["dataset_id"] == "home/env/temperature"
+
+    logs = client.get("/audit/logs?limit=5").json()
+    latest = logs[0]
+    assert latest["action"] == "allow"
+    assert latest["presentation_verified"] == "allow"
+    assert latest["holder_did"] == holder_did
+    assert latest["dataset_id"] == "home/env/temperature"
+    assert latest["vc_hash"].startswith("sha256:")
+
+
+def test_purpose_mismatch_denied(client):
+    holder_priv, holder_pub, _ = _make_holder_key()
+    offer = client.get(
+        "/issuer/offer",
+        params={"type": "ConsentVC", "dataset_id": "home/env/temperature", "purpose": "research"},
+        headers={"accept": "application/json"},
+    ).json()
+    token = client.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": offer["pre_authorized_code"],
+        },
+    ).json()
+    proof = _make_proof_jwt(holder_priv, holder_pub, token["c_nonce"], "http://testserver")
+    cred = client.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+        json={
+            "format": "vc+sd-jwt",
+            "proof": {"proof_type": "jwt", "jwt": proof},
+        },
+    ).json()
+
+    # Request verification with a purpose that is NOT in allowed_purposes
+    req = client.get(
+        "/verifier/request",
+        params={"dataset_id": "home/env/temperature", "purpose": "marketing"},
+        headers={"accept": "application/json"},
+    ).json()
+    submission = _make_presentation_submission("consent-temperature", "consent_vc_temperature")
+    r = client.post(
+        "/verifier/response",
+        data={
+            "vp_token": cred["credential"],
+            "presentation_submission": json.dumps(submission),
+            "state": req["state"],
+        },
+    )
+    body = r.json()
+    assert body["status"] == "denied"
+    assert body["reason"] == "purpose_mismatch"
+
+    logs = client.get("/audit/logs?limit=5").json()
+    assert logs[0]["action"] == "deny"
+    assert logs[0]["presentation_verified"] == "deny"
+    assert logs[0]["reason"] == "purpose_mismatch"
+
+
+def test_phase1_consents_still_work(client):
+    """Ensure Phase 1 /consents + /simulate/publish remain non-breaking."""
+    consent = {
+        "vc_id": "consent-test-1",
+        "subject_did": "did:example:alice",
+        "dataset_id": "home/env/temperature",
+        "allowed_purposes": ["research"],
+        "retention_days": 30,
+        "reshare_allowed": False,
+        "valid_from": "2024-01-01T00:00:00Z",
+        "valid_to": "2099-01-01T00:00:00Z",
+        "signature": "stub",
+    }
+    r = client.post("/consents", json=consent)
+    assert r.status_code == 200, r.text
+    listed = client.get("/consents").json()
+    assert any(c["vc_id"] == "consent-test-1" for c in listed)


### PR DESCRIPTION
## Summary
- Add OID4VCI issuer endpoints (\`/issuer/offer\`, \`/issuer/token\`, \`/issuer/credential\`, \`.well-known/openid-credential-issuer\`) and OID4VP verifier endpoints (\`/verifier/presentation-definitions/{id}\`, \`/verifier/request\`, \`/verifier/response\`) inside the publisher
- Use \`did:jwk\` keys and SD-JWT VC format, with a Node.js verifier sidecar using \`@sphereon/pex\` for presentation verification
- Extend the audit log with \`holder_did\`, \`vc_hash\`, and \`presentation_verified\` fields
- Add Docker Compose profile \`ssi-wallet\` to bring up the added services
- Ship sample Presentation Definitions (\`consent-temperature\`, \`consent-person-detected\`, \`consent-flood-risk-high\`) and an end-to-end integration test (\`tests/test_ssi_wallet_flow.py\`)

Fourth of a 4-PR split. **Depends on PR3** — please merge #8 first.

Backs the hands-on page [\`docs/hands-on/ha-ssi-wallet.md\`](https://github.com/ertlnagoya/iw3ip.github.io/blob/main/docs/hands-on/ha-ssi-wallet.md) in iw3ip.github.io.

## Test plan
- [ ] \`pytest tests/test_ssi_wallet_flow.py\` green
- [ ] \`docker compose -f infra/docker-compose.yml --profile ssi-wallet up --build -d\` brings up publisher + verifier sidecar
- [ ] End-to-end with ertlnagoya/iw3ip-wallet (forked Sphereon mobile-wallet): issuer QR -> VC stored -> verifier QR -> \`allowed\`
- [ ] \`purpose\` mismatch returns \`denied\` with \`purpose_mismatch\` reason
- [ ] Audit log entries include \`holder_did\` and \`vc_hash\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)