### PR TITLE
Align OID4VCI/OID4VP publisher with current Sphereon wallet drafts

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       PUBLISHER_ID: publisher-001
       AUDIT_DB_PATH: /data/audit.db
       CONSENT_STORE_PATH: /data/consents.json
-      SSI_ISSUER_BASE_URL: http://publisher:8080
+      SSI_ISSUER_BASE_URL: ${SSI_ISSUER_BASE_URL:-http://publisher:8080}
       SSI_ISSUER_KEY_PATH: /data/issuer_key.jwk.json
       SSI_PEX_SIDECAR_URL: http://verifier-sidecar:7000
       SSI_PRESENTATION_DEFS_DIR: /app/examples/ssi_wallet
@@ -41,7 +41,7 @@ services:
     environment:
       PORT: "7000"
     ports:
-      - "7000:7000"
+      - "7100:7000"
 
   nodered:
     image: nodered/node-red:latest

--- a/publisher/Dockerfile
+++ b/publisher/Dockerfile
@@ -18,7 +18,8 @@ RUN pip install --no-cache-dir --upgrade pip && \
         'httpx>=0.28' \
         paho-mqtt \
         'cryptography>=42' \
-        python-multipart
+        python-multipart \
+        'qrcode[pil]>=7'
 
 EXPOSE 8080
 

--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -48,6 +48,26 @@ mqtt_subscriber = MQTTSubscriber(
 app = FastAPI(title="IW3IP Data Publisher", version="0.1.0")
 app.state.ingested = []
 
+import logging
+from starlette.requests import Request as _StarletteRequest
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+_ssi_error_log = logging.getLogger("ssi.error")
+
+
+@app.exception_handler(HTTPException)
+async def _log_http_exception(request: _StarletteRequest, exc: HTTPException):
+    if exc.status_code >= 400:
+        _ssi_error_log.error("HTTP %s on %s %s: %s", exc.status_code, request.method, request.url.path, exc.detail)
+    return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+
+@app.exception_handler(RequestValidationError)
+async def _log_validation_exception(request: _StarletteRequest, exc: RequestValidationError):
+    _ssi_error_log.error("422 on %s %s: %s", request.method, request.url.path, exc.errors())
+    return JSONResponse(status_code=422, content={"detail": exc.errors()})
+
 ssi_keys = IssuerKeyStore(ssi_settings.issuer_key_path)
 ssi_state = SSIStateStore(
     offer_ttl=ssi_settings.offer_ttl_seconds,

--- a/publisher/app/ssi/html.py
+++ b/publisher/app/ssi/html.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import base64
 import html as _html
+import io
 
 
 _QR_PAGE = """<!DOCTYPE html>
@@ -10,7 +12,7 @@ _QR_PAGE = """<!DOCTYPE html>
   <title>{title}</title>
   <style>
     body {{ font-family: system-ui, sans-serif; padding: 2rem; max-width: 720px; margin: 0 auto; }}
-    #qr {{ margin: 1rem 0; }}
+    img.qr {{ margin: 1rem 0; image-rendering: pixelated; width: 320px; height: 320px; }}
     pre {{ background: #f4f4f4; padding: 1rem; overflow-x: auto; font-size: 0.85rem; }}
     a.deeplink {{ display: inline-block; margin-top: 0.5rem; }}
   </style>
@@ -18,16 +20,23 @@ _QR_PAGE = """<!DOCTYPE html>
 <body>
   <h1>{title}</h1>
   <p>{subtitle}</p>
-  <div id="qr"></div>
+  <img class="qr" alt="QR code for {deeplink_label}" src="{qr_data_uri}" />
   <p><a class="deeplink" href="{deeplink}">{deeplink_label}</a></p>
   <details open><summary>payload</summary><pre>{payload_json}</pre></details>
-  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
-  <script>
-    QRCode.toCanvas(document.getElementById('qr'), {deeplink_js}, {{ width: 320 }});
-  </script>
 </body>
 </html>
 """
+
+
+def _render_qr_data_uri(text: str) -> str:
+    try:
+        import qrcode  # type: ignore
+    except ImportError:
+        return ""
+    img = qrcode.make(text, box_size=8, border=2)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode("ascii")
 
 
 def render_qr_page(
@@ -38,7 +47,7 @@ def render_qr_page(
     deeplink_label: str,
     payload_json: str,
 ) -> str:
-    import json as _json
+    qr_data_uri = _render_qr_data_uri(deeplink)
 
     return _QR_PAGE.format(
         title=_html.escape(title),
@@ -46,5 +55,5 @@ def render_qr_page(
         deeplink=_html.escape(deeplink, quote=True),
         deeplink_label=_html.escape(deeplink_label),
         payload_json=_html.escape(payload_json),
-        deeplink_js=_json.dumps(deeplink),
+        qr_data_uri=_html.escape(qr_data_uri, quote=True),
     )

--- a/publisher/app/ssi/issuer_routes.py
+++ b/publisher/app/ssi/issuer_routes.py
@@ -61,7 +61,7 @@ def _credential_issuer_metadata(settings: SSISettings, keys: IssuerKeyStore) -> 
         "authorization_servers": [settings.issuer_base_url],
         "credential_configurations_supported": {
             CREDENTIAL_CONFIG_ID: {
-                "format": "vc+sd-jwt",
+                "format": "dc+sd-jwt",
                 "vct": VCT,
                 "scope": "ConsentVC",
                 "cryptographic_binding_methods_supported": ["jwk", "did:jwk"],
@@ -225,8 +225,10 @@ def build_router(deps: IssuerDeps) -> APIRouter:
 
         cfg_id = body.get("credential_configuration_id") or body.get("credential_identifier")
         fmt = body.get("format")
-        if not (cfg_id == CREDENTIAL_CONFIG_ID or fmt == "vc+sd-jwt"):
-            raise HTTPException(status_code=400, detail=f"only vc+sd-jwt supported (got format={fmt}, cfg_id={cfg_id})")
+        # Accept both the new (`dc+sd-jwt`) and legacy (`vc+sd-jwt`) SD-JWT VC media
+        # type names so wallets that pin to either draft revision can still issue.
+        if not (cfg_id == CREDENTIAL_CONFIG_ID or fmt in ("dc+sd-jwt", "vc+sd-jwt")):
+            raise HTTPException(status_code=400, detail=f"only sd-jwt vc supported (got format={fmt}, cfg_id={cfg_id})")
         if body.get("vct") and body["vct"] != VCT:
             raise HTTPException(status_code=400, detail=f"unknown vct: {body['vct']}")
 
@@ -267,6 +269,6 @@ def build_router(deps: IssuerDeps) -> APIRouter:
             iat=now,
             exp=exp,
         )
-        return {"credential": vc.compact, "format": "vc+sd-jwt"}
+        return {"credential": vc.compact, "format": "dc+sd-jwt"}
 
     return router

--- a/publisher/app/ssi/issuer_routes.py
+++ b/publisher/app/ssi/issuer_routes.py
@@ -223,17 +223,25 @@ def build_router(deps: IssuerDeps) -> APIRouter:
         if not offer:
             raise HTTPException(status_code=400, detail="no_offer_for_token")
 
-        if body.get("format") != "vc+sd-jwt":
-            raise HTTPException(status_code=400, detail="only vc+sd-jwt supported")
+        cfg_id = body.get("credential_configuration_id") or body.get("credential_identifier")
+        fmt = body.get("format")
+        if not (cfg_id == CREDENTIAL_CONFIG_ID or fmt == "vc+sd-jwt"):
+            raise HTTPException(status_code=400, detail=f"only vc+sd-jwt supported (got format={fmt}, cfg_id={cfg_id})")
         if body.get("vct") and body["vct"] != VCT:
             raise HTTPException(status_code=400, detail=f"unknown vct: {body['vct']}")
 
         proof = body.get("proof") or {}
-        if proof.get("proof_type") != "jwt" or "jwt" not in proof:
+        proofs = body.get("proofs") or {}
+        proof_jwt = None
+        if isinstance(proof, dict) and proof.get("proof_type") == "jwt" and "jwt" in proof:
+            proof_jwt = proof["jwt"]
+        elif isinstance(proofs, dict) and isinstance(proofs.get("jwt"), list) and proofs["jwt"]:
+            proof_jwt = proofs["jwt"][0]
+        if not proof_jwt:
             raise HTTPException(status_code=400, detail="proof_type=jwt required")
 
         holder_jwk = _parse_proof_jwt(
-            proof["jwt"],
+            proof_jwt,
             expected_nonce=token.c_nonce,
             expected_aud=deps.settings.issuer_base_url,
         )

--- a/publisher/app/ssi/issuer_routes.py
+++ b/publisher/app/ssi/issuer_routes.py
@@ -14,6 +14,7 @@ from publisher.app.ssi.html import render_qr_page
 from publisher.app.ssi.keys import IssuerKeyStore
 from publisher.app.ssi.sdjwt import issue_sd_jwt_vc
 from publisher.app.ssi.state import SSIStateStore
+from publisher.app.ssi.url_utils import externally_reachable_base_url
 
 
 CREDENTIAL_CONFIG_ID = "ConsentVC"
@@ -40,9 +41,9 @@ def _issuer_did(keys: IssuerKeyStore) -> str:
     return did_jwk_from_public_jwk(keys.public_jwk)
 
 
-def _credential_offer(settings: SSISettings, pre_auth_code: str) -> dict:
+def _credential_offer(base_url: str, pre_auth_code: str) -> dict:
     return {
-        "credential_issuer": settings.issuer_base_url,
+        "credential_issuer": base_url,
         "credential_configuration_ids": [CREDENTIAL_CONFIG_ID],
         "grants": {
             "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
@@ -52,13 +53,13 @@ def _credential_offer(settings: SSISettings, pre_auth_code: str) -> dict:
     }
 
 
-def _credential_issuer_metadata(settings: SSISettings, keys: IssuerKeyStore) -> dict:
+def _credential_issuer_metadata(base_url: str, keys: IssuerKeyStore) -> dict:
     issuer_did = _issuer_did(keys)
     return {
-        "credential_issuer": settings.issuer_base_url,
-        "token_endpoint": f"{settings.issuer_base_url}/issuer/token",
-        "credential_endpoint": f"{settings.issuer_base_url}/issuer/credential",
-        "authorization_servers": [settings.issuer_base_url],
+        "credential_issuer": base_url,
+        "token_endpoint": f"{base_url}/issuer/token",
+        "credential_endpoint": f"{base_url}/issuer/credential",
+        "authorization_servers": [base_url],
         "credential_configurations_supported": {
             CREDENTIAL_CONFIG_ID: {
                 "format": "dc+sd-jwt",
@@ -127,12 +128,13 @@ def build_router(deps: IssuerDeps) -> APIRouter:
     router = APIRouter()
 
     @router.get("/.well-known/openid-credential-issuer")
-    def issuer_metadata() -> dict:
-        return _credential_issuer_metadata(deps.settings, deps.keys)
+    def issuer_metadata(request: Request) -> dict:
+        base = externally_reachable_base_url(request, deps.settings.issuer_base_url)
+        return _credential_issuer_metadata(base, deps.keys)
 
     @router.get("/.well-known/oauth-authorization-server")
-    def as_metadata() -> dict:
-        base = deps.settings.issuer_base_url
+    def as_metadata(request: Request) -> dict:
+        base = externally_reachable_base_url(request, deps.settings.issuer_base_url)
         return {
             "issuer": base,
             "token_endpoint": f"{base}/issuer/token",
@@ -160,7 +162,8 @@ def build_router(deps: IssuerDeps) -> APIRouter:
             purpose=purpose,
             allowed_purposes=allowed,
         )
-        co = _credential_offer(deps.settings, offer.pre_authorized_code)
+        public_base = externally_reachable_base_url(request, deps.settings.issuer_base_url)
+        co = _credential_offer(public_base, offer.pre_authorized_code)
         deeplink = (
             DEEPLINK_SCHEME
             + "?credential_offer="
@@ -210,6 +213,7 @@ def build_router(deps: IssuerDeps) -> APIRouter:
 
     @router.post("/issuer/credential")
     def issuer_credential(
+        request: Request,
         body: dict,
         authorization: str | None = Header(default=None),
     ):
@@ -242,10 +246,14 @@ def build_router(deps: IssuerDeps) -> APIRouter:
         if not proof_jwt:
             raise HTTPException(status_code=400, detail="proof_type=jwt required")
 
+        # Wallets sign the proof JWT with whatever issuer URL they fetched the
+        # offer/metadata under. That's the externally-reachable URL we just
+        # echoed back, not the docker-internal `settings.issuer_base_url`.
+        public_base = externally_reachable_base_url(request, deps.settings.issuer_base_url)
         holder_jwk = _parse_proof_jwt(
             proof_jwt,
             expected_nonce=token.c_nonce,
-            expected_aud=deps.settings.issuer_base_url,
+            expected_aud=public_base,
         )
 
         now = int(time.time())

--- a/publisher/app/ssi/sdjwt.py
+++ b/publisher/app/ssi/sdjwt.py
@@ -105,7 +105,7 @@ def issue_sd_jwt_vc(
     if sd_digests:
         body["_sd"] = sd_digests
 
-    header = {"alg": "ES256", "typ": "vc+sd-jwt", "kid": issuer_did + "#0"}
+    header = {"alg": "ES256", "typ": "dc+sd-jwt", "kid": issuer_did + "#0"}
     signing_input = _b64u(_json_bytes(header)).encode("ascii") + b"." + _b64u(_json_bytes(body)).encode("ascii")
     sig = _es256_sign(issuer_private_jwk, signing_input)
     jwt = signing_input.decode("ascii") + "." + _b64u(sig)

--- a/publisher/app/ssi/url_utils.py
+++ b/publisher/app/ssi/url_utils.py
@@ -1,0 +1,40 @@
+"""Helpers for picking URLs the wallet can actually reach.
+
+The publisher runs inside Docker and binds the configured `SSI_ISSUER_BASE_URL`
+(default `http://publisher:8080`) into every protocol message. That hostname
+only resolves inside the Compose network, so any URL the wallet has to fetch
+or post to (issuer metadata, credential offer's `credential_issuer`, token
+and credential endpoints, OID4VP `request_uri` / `response_uri`) is unusable
+when the wallet sits on the host LAN or a phone.
+
+When the configured base points at a known-internal host
+(publisher/localhost/127.*/0.0.0.0), fall back to the scheme+host of the
+inbound HTTP request: by definition that's how the caller reached us, so
+echoing it back gives them a URL that round-trips. `client_id`, `iss`, `aud`
+keep the configured value because they are stable identifiers, not fetch
+targets.
+"""
+
+from __future__ import annotations
+
+import urllib.parse
+
+from fastapi import Request
+
+
+_INTERNAL_HOST_PREFIXES = ("publisher", "localhost", "127.", "0.0.0.0")
+
+
+def externally_reachable_base_url(request: Request, configured: str) -> str:
+    try:
+        parsed = urllib.parse.urlsplit(configured)
+    except ValueError:
+        parsed = None
+    host = (parsed.hostname or "") if parsed else ""
+    if host and not any(host == p.rstrip(".") or host.startswith(p) for p in _INTERNAL_HOST_PREFIXES):
+        return configured.rstrip("/")
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    forwarded_host = request.headers.get("x-forwarded-host") or request.headers.get("host")
+    scheme = forwarded_proto or request.url.scheme
+    host_header = forwarded_host or request.url.netloc
+    return f"{scheme}://{host_header}".rstrip("/")

--- a/publisher/app/ssi/verifier_routes.py
+++ b/publisher/app/ssi/verifier_routes.py
@@ -42,6 +42,32 @@ def _vc_hash(vp_token: str) -> str:
     return "sha256:" + hashlib.sha256(compact.encode("utf-8")).hexdigest()
 
 
+def _extract_sd_jwt_compact(raw_vp_token: str) -> str:
+    """Pull the SD-JWT VC compact string out of whatever shape `vp_token` arrives in.
+
+    PEX/SIOPv2 responses send `vp_token` as a single SD-JWT VC compact string.
+    DCQL responses send it as a JSON object keyed by the credential query id
+    (e.g. `{"consent_vc": "<sd-jwt>"}`) or by an array of strings. Newer wallets
+    may also send a JSON array. Accept all three shapes.
+    """
+    s = (raw_vp_token or "").strip()
+    if not s or s[0] not in "{[":
+        return raw_vp_token
+    try:
+        data = json.loads(s)
+    except json.JSONDecodeError:
+        return raw_vp_token
+    if isinstance(data, dict):
+        for v in data.values():
+            if isinstance(v, str) and v:
+                return v
+            if isinstance(v, list) and v and isinstance(v[0], str):
+                return v[0]
+    if isinstance(data, list) and data and isinstance(data[0], str):
+        return data[0]
+    return raw_vp_token
+
+
 def _write_audit(
     audit_repo: SQLiteAuditRepository,
     *,
@@ -125,6 +151,15 @@ def _local_pex_fallback(
 
         holder_did = did_jwk_from_public_jwk(cnf)
     return {"verified": True, "reason": "ok", "claims": claims, "holder_did": holder_did}
+
+
+def _safe_local_pex_fallback(pd, sd_jwt, deps, req):
+    try:
+        return _local_pex_fallback(
+            pd, sd_jwt, deps.keys.public_jwk, req.dataset_id, req.purpose
+        )
+    except Exception as fb_exc:  # noqa: BLE001
+        return {"verified": False, "reason": f"verify_error:{fb_exc}", "claims": {}, "holder_did": None}
 
 
 def build_router(deps: VerifierDeps) -> APIRouter:
@@ -232,8 +267,11 @@ def build_router(deps: VerifierDeps) -> APIRouter:
     @router.post("/verifier/response")
     def verifier_response(
         vp_token: str = Form(...),
-        presentation_submission: str = Form(...),
         state: str = Form(...),
+        # Only sent for PEX (presentation_definition) responses. DCQL responses
+        # have no equivalent — the wallet keys `vp_token` by credential query id
+        # instead. Keep the field optional so both shapes are accepted.
+        presentation_submission: str | None = Form(default=None),
     ):
         req = deps.state.find_verification_request(state)
         if not req:
@@ -243,26 +281,27 @@ def build_router(deps: VerifierDeps) -> APIRouter:
         if not pd:
             raise HTTPException(status_code=500, detail="presentation_definition_missing")
 
-        submission = json.loads(presentation_submission)
-        vc_hash_value = _vc_hash(vp_token)
+        sd_jwt = _extract_sd_jwt_compact(vp_token)
+        vc_hash_value = _vc_hash(sd_jwt)
 
-        try:
-            result = deps.pex_client.verify(
-                presentation_definition=pd,
-                vp_token=vp_token,
-                presentation_submission=submission,
-                issuer_public_jwk=deps.keys.public_jwk,
-                expected_nonce=req.nonce,
-                expected_aud=deps.settings.issuer_base_url,
-            )
-        except (httpx.HTTPError, httpx.InvalidURL) as exc:
-            logger.warning("PEX sidecar unreachable (%s); using local fallback", exc)
+        if presentation_submission is not None:
+            submission = json.loads(presentation_submission)
             try:
-                result = _local_pex_fallback(
-                    pd, vp_token, deps.keys.public_jwk, req.dataset_id, req.purpose
+                result = deps.pex_client.verify(
+                    presentation_definition=pd,
+                    vp_token=sd_jwt,
+                    presentation_submission=submission,
+                    issuer_public_jwk=deps.keys.public_jwk,
+                    expected_nonce=req.nonce,
+                    expected_aud=deps.settings.issuer_base_url,
                 )
-            except Exception as fb_exc:  # noqa: BLE001
-                result = {"verified": False, "reason": f"verify_error:{fb_exc}", "claims": {}, "holder_did": None}
+            except (httpx.HTTPError, httpx.InvalidURL) as exc:
+                logger.warning("PEX sidecar unreachable (%s); using local fallback", exc)
+                result = _safe_local_pex_fallback(pd, sd_jwt, deps, req)
+        else:
+            # DCQL path: PEX sidecar speaks PEX, not DCQL, so go straight to the
+            # local fallback that re-checks the disclosed claims directly.
+            result = _safe_local_pex_fallback(pd, sd_jwt, deps, req)
 
         verified = bool(result.get("verified"))
         reason = result.get("reason") or ("ok" if verified else "verification_failed")

--- a/publisher/app/ssi/verifier_routes.py
+++ b/publisher/app/ssi/verifier_routes.py
@@ -21,6 +21,7 @@ from publisher.app.ssi.pex_client import PEXSidecarClient
 from publisher.app.ssi.presentation_defs import PresentationDefinitionStore
 from publisher.app.ssi.sdjwt import parse_sd_jwt_vc, verify_sd_jwt_vc
 from publisher.app.ssi.state import SSIStateStore
+from publisher.app.ssi.url_utils import externally_reachable_base_url
 
 
 logger = logging.getLogger(__name__)
@@ -39,31 +40,6 @@ class VerifierDeps:
 def _vc_hash(vp_token: str) -> str:
     compact = vp_token.split("~")[0]
     return "sha256:" + hashlib.sha256(compact.encode("utf-8")).hexdigest()
-
-
-# Mobile wallets must be able to fetch `request_uri` and POST to `response_uri`
-# from outside the Docker network, so any host that only resolves inside
-# Compose (the default `http://publisher:8080`, `http://localhost:...`,
-# `127.*`) is unusable. When the configured `issuer_base_url` falls into that
-# bucket, fall back to the scheme/host the inbound request actually used —
-# this is what the wallet (or whoever forwarded the deeplink) reached us on,
-# and is by definition reachable from there.
-_INTERNAL_HOST_PREFIXES = ("publisher", "localhost", "127.", "0.0.0.0")
-
-
-def _externally_reachable_base_url(request: Request, configured: str) -> str:
-    try:
-        parsed = urllib.parse.urlsplit(configured)
-    except ValueError:
-        parsed = None
-    host = (parsed.hostname or "") if parsed else ""
-    if host and not any(host == p.rstrip(".") or host.startswith(p) for p in _INTERNAL_HOST_PREFIXES):
-        return configured.rstrip("/")
-    forwarded_proto = request.headers.get("x-forwarded-proto")
-    forwarded_host = request.headers.get("x-forwarded-host") or request.headers.get("host")
-    scheme = forwarded_proto or request.url.scheme
-    host_header = forwarded_host or request.url.netloc
-    return f"{scheme}://{host_header}".rstrip("/")
 
 
 def _write_audit(
@@ -173,7 +149,7 @@ def build_router(deps: VerifierDeps) -> APIRouter:
         pd_id, pd = match
         req = deps.state.create_verification_request(pd_id, dataset_id, purpose)
 
-        public_base = _externally_reachable_base_url(request, deps.settings.issuer_base_url)
+        public_base = externally_reachable_base_url(request, deps.settings.issuer_base_url)
         authz = {
             "response_type": "vp_token",
             "response_mode": "direct_post",
@@ -234,7 +210,7 @@ def build_router(deps: VerifierDeps) -> APIRouter:
                 }
             ]
         }
-        public_base = _externally_reachable_base_url(request, deps.settings.issuer_base_url)
+        public_base = externally_reachable_base_url(request, deps.settings.issuer_base_url)
         payload = {
             "response_type": "vp_token",
             "response_mode": "direct_post",

--- a/publisher/app/ssi/verifier_routes.py
+++ b/publisher/app/ssi/verifier_routes.py
@@ -224,7 +224,7 @@ def build_router(deps: VerifierDeps) -> APIRouter:
             "credentials": [
                 {
                     "id": "consent_vc",
-                    "format": "vc+sd-jwt",
+                    "format": "dc+sd-jwt",
                     "meta": {"vct_values": ["https://iw3ip.example/credentials/ConsentVC/v1"]},
                     "claims": [
                         {"path": ["dataset_id"], "values": [req.dataset_id]},

--- a/publisher/app/ssi/verifier_routes.py
+++ b/publisher/app/ssi/verifier_routes.py
@@ -157,10 +157,11 @@ def build_router(deps: VerifierDeps) -> APIRouter:
             "nonce": req.nonce,
             "state": req.state,
         }
+        request_uri = f"{deps.settings.issuer_base_url}/verifier/request_object?state={req.state}"
         deeplink = "openid4vp://?" + urllib.parse.urlencode(
             {
                 "client_id": authz["client_id"],
-                "request": json.dumps(authz, separators=(",", ":")),
+                "request_uri": request_uri,
             }
         )
 
@@ -181,6 +182,49 @@ def build_router(deps: VerifierDeps) -> APIRouter:
             payload_json=json.dumps(authz, indent=2, ensure_ascii=False),
         )
         return HTMLResponse(html)
+
+    @router.get("/verifier/request_object")
+    def verifier_request_object(state: str = Query(...)):
+        from fastapi.responses import Response as _Response
+        from publisher.app.ssi.sdjwt import _b64u, _es256_sign, _json_bytes
+        from publisher.app.ssi.did_jwk import did_jwk_from_public_jwk
+        req = deps.state.find_verification_request(state)
+        if not req:
+            raise HTTPException(status_code=404, detail="verification_request_not_found")
+        pd = deps.definitions.get(req.presentation_definition_id)
+        kid = did_jwk_from_public_jwk(deps.keys.public_jwk) + "#0"
+        header = {"alg": "ES256", "typ": "oauth-authz-req+jwt", "kid": kid}
+        dcql = {
+            "credentials": [
+                {
+                    "id": "consent_vc",
+                    "format": "vc+sd-jwt",
+                    "meta": {"vct_values": ["https://iw3ip.example/credentials/ConsentVC/v1"]},
+                    "claims": [
+                        {"path": ["dataset_id"], "values": [req.dataset_id]},
+                        {"path": ["allowed_purposes"]},
+                        {"path": ["subject_id"]},
+                    ],
+                }
+            ]
+        }
+        payload = {
+            "response_type": "vp_token",
+            "response_mode": "direct_post",
+            "client_id": deps.settings.issuer_base_url,
+            "response_uri": f"{deps.settings.issuer_base_url}/verifier/response",
+            "dcql_query": dcql,
+            "nonce": req.nonce,
+            "state": req.state,
+            "iss": deps.settings.issuer_base_url,
+            "aud": "https://self-issued.me/v2",
+        }
+        h_b64 = _b64u(_json_bytes(header))
+        p_b64 = _b64u(_json_bytes(payload))
+        signing_input = (h_b64 + "." + p_b64).encode("ascii")
+        sig = _es256_sign(deps.keys.private_jwk, signing_input)
+        jwt = h_b64 + "." + p_b64 + "." + _b64u(sig)
+        return _Response(content=jwt, media_type="application/oauth-authz-req+jwt")
 
     @router.post("/verifier/response")
     def verifier_response(

--- a/publisher/app/ssi/verifier_routes.py
+++ b/publisher/app/ssi/verifier_routes.py
@@ -41,6 +41,31 @@ def _vc_hash(vp_token: str) -> str:
     return "sha256:" + hashlib.sha256(compact.encode("utf-8")).hexdigest()
 
 
+# Mobile wallets must be able to fetch `request_uri` and POST to `response_uri`
+# from outside the Docker network, so any host that only resolves inside
+# Compose (the default `http://publisher:8080`, `http://localhost:...`,
+# `127.*`) is unusable. When the configured `issuer_base_url` falls into that
+# bucket, fall back to the scheme/host the inbound request actually used —
+# this is what the wallet (or whoever forwarded the deeplink) reached us on,
+# and is by definition reachable from there.
+_INTERNAL_HOST_PREFIXES = ("publisher", "localhost", "127.", "0.0.0.0")
+
+
+def _externally_reachable_base_url(request: Request, configured: str) -> str:
+    try:
+        parsed = urllib.parse.urlsplit(configured)
+    except ValueError:
+        parsed = None
+    host = (parsed.hostname or "") if parsed else ""
+    if host and not any(host == p.rstrip(".") or host.startswith(p) for p in _INTERNAL_HOST_PREFIXES):
+        return configured.rstrip("/")
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    forwarded_host = request.headers.get("x-forwarded-host") or request.headers.get("host")
+    scheme = forwarded_proto or request.url.scheme
+    host_header = forwarded_host or request.url.netloc
+    return f"{scheme}://{host_header}".rstrip("/")
+
+
 def _write_audit(
     audit_repo: SQLiteAuditRepository,
     *,
@@ -148,16 +173,17 @@ def build_router(deps: VerifierDeps) -> APIRouter:
         pd_id, pd = match
         req = deps.state.create_verification_request(pd_id, dataset_id, purpose)
 
+        public_base = _externally_reachable_base_url(request, deps.settings.issuer_base_url)
         authz = {
             "response_type": "vp_token",
             "response_mode": "direct_post",
             "client_id": deps.settings.issuer_base_url,
-            "response_uri": f"{deps.settings.issuer_base_url}/verifier/response",
+            "response_uri": f"{public_base}/verifier/response",
             "presentation_definition": pd,
             "nonce": req.nonce,
             "state": req.state,
         }
-        request_uri = f"{deps.settings.issuer_base_url}/verifier/request_object?state={req.state}"
+        request_uri = f"{public_base}/verifier/request_object?state={req.state}"
         deeplink = "openid4vp://?" + urllib.parse.urlencode(
             {
                 "client_id": authz["client_id"],
@@ -184,7 +210,7 @@ def build_router(deps: VerifierDeps) -> APIRouter:
         return HTMLResponse(html)
 
     @router.get("/verifier/request_object")
-    def verifier_request_object(state: str = Query(...)):
+    def verifier_request_object(request: Request, state: str = Query(...)):
         from fastapi.responses import Response as _Response
         from publisher.app.ssi.sdjwt import _b64u, _es256_sign, _json_bytes
         from publisher.app.ssi.did_jwk import did_jwk_from_public_jwk
@@ -208,11 +234,12 @@ def build_router(deps: VerifierDeps) -> APIRouter:
                 }
             ]
         }
+        public_base = _externally_reachable_base_url(request, deps.settings.issuer_base_url)
         payload = {
             "response_type": "vp_token",
             "response_mode": "direct_post",
             "client_id": deps.settings.issuer_base_url,
-            "response_uri": f"{deps.settings.issuer_base_url}/verifier/response",
+            "response_uri": f"{public_base}/verifier/response",
             "dcql_query": dcql,
             "nonce": req.nonce,
             "state": req.state,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "paho-mqtt>=2.1.0",
   "cryptography>=42",
   "python-multipart>=0.0.9",
+  "qrcode[pil]>=7",
 ]
 
 [dependency-groups]

--- a/ssi/verifier-sidecar/package.json
+++ b/ssi/verifier-sidecar/package.json
@@ -9,7 +9,7 @@
     "start": "node src/server.js"
   },
   "dependencies": {
-    "@sphereon/pex": "^5.0.0",
+    "@sphereon/pex": "5.0.0-unstable.28",
     "express": "^4.21.0",
     "jose": "^5.9.6"
   },


### PR DESCRIPTION
## Summary

- Accept newer OID4VCI request shapes (`credential_configuration_id`, `proofs[]`) so the Sphereon mobile-wallet fork (`ertlnagoya/iw3ip-wallet`) can complete VC issuance.
- Serve the OID4VP authorization request as a signed ES256 JWT at `/verifier/request_object` and reference it via `request_uri` in the `openid4vp://` deeplink, matching the request_uri-only flow newer wallets implement.
- Switch the request from Presentation Exchange (`presentation_definition`) to `dcql_query` since the wallet now rejects PE as an older draft.
- Make `SSI_ISSUER_BASE_URL` overridable via env so the wallet can reach the publisher on the host LAN IP; default still resolves inside the compose network. Verifier sidecar moves to host port 7100 to dodge the macOS AirPlay Receiver clash on 7000.
- Pin `@sphereon/pex` to `5.0.0-unstable.28` since no stable `^5.0.0` is published.
- Log `HTTPException` / `RequestValidationError` detail so SSI flow errors are visible in publisher logs instead of bare 4xx status lines.

## Verification

End-to-end on iPhone with iw3ip-wallet:
- VC issuance (pre-authorized_code → token → credential) ✅
- Verifier request object fetched and DCQL-parsed by the wallet ✅
- Presentation submission ❌ — blocked by an unrelated wallet-side React Navigation bug (`SIOPV2` screen not registered). Tracked separately.

## Test plan

- [ ] `docker compose -f infra/docker-compose.yml --profile ssi-wallet up --build -d publisher verifier-sidecar mosquitto` starts cleanly
- [ ] `curl localhost:8080/health` and `curl localhost:8080/.well-known/openid-credential-issuer` return 200
- [ ] Existing automated tests under `tests/test_ssi_wallet_flow.py` still pass
- [ ] Issuing the VC from `iw3ip-wallet` against `SSI_ISSUER_BASE_URL=http://<LAN_IP>:8080` succeeds (publisher logs `POST /issuer/credential 200`)
- [ ] `/verifier/request_object?state=...` returns `application/oauth-authz-req+jwt` with valid ES256 signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)