### PR TITLE
feat(ssi): gate /platform/ingest behind PolicyToken from OID4VP

### DIFF
--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-from fastapi import FastAPI, HTTPException
+from datetime import datetime, timezone
 
+from fastapi import FastAPI, Header, HTTPException
+
+from audit.models import AuditLogRecord
 from audit.repository import SQLiteAuditRepository
 from policy.engine import PolicyEngine
 from policy.models import ConsentVC
@@ -142,7 +145,54 @@ def list_audit_logs(limit: int = 100) -> list[dict]:
 
 
 @app.post("/platform/ingest")
-def platform_ingest(body: dict) -> dict:
+def platform_ingest(
+    body: dict,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    # Bearer header is the wallet/PolicyToken path. No header = legacy
+    # Phase 2 consent_store path (see /consents JSON), kept for the existing
+    # webcam-event-sharing / environment-disaster hands-on flows.
+    if authorization:
+        scheme, _, token = authorization.partition(" ")
+        if scheme.lower() != "bearer" or not token:
+            raise HTTPException(status_code=401, detail="invalid_authorization_header")
+        dataset_id = body.get("dataset_id")
+        if not dataset_id:
+            raise HTTPException(status_code=400, detail="dataset_id_required")
+        pt, reason = ssi_state.consume_policy_token(token, dataset_id=dataset_id)
+        if not pt:
+            audit_repo.write(
+                AuditLogRecord(
+                    ts=datetime.now(timezone.utc).isoformat(),
+                    action="deny",
+                    subject_did="unknown",
+                    dataset_id=str(dataset_id),
+                    purpose=str(body.get("purpose") or "unknown"),
+                    reason=f"policy_token_{reason}",
+                    message_hash="",
+                    raw_topic="platform/ingest",
+                    holder_did=None,
+                    vc_hash=None,
+                    presentation_verified="deny",
+                )
+            )
+            status = 401 if reason in ("unknown", "expired") else 403
+            raise HTTPException(status_code=status, detail=f"policy_token_{reason}")
+        audit_repo.write(
+            AuditLogRecord(
+                ts=datetime.now(timezone.utc).isoformat(),
+                action="allow",
+                subject_did=pt.holder_did or "unknown",
+                dataset_id=pt.dataset_id,
+                purpose=pt.purpose,
+                reason=f"policy_token_consumed:{pt.jti}",
+                message_hash="",
+                raw_topic="platform/ingest",
+                holder_did=pt.holder_did,
+                vc_hash=None,
+                presentation_verified="allow",
+            )
+        )
     app.state.ingested.append(body)
     return {"status": "received", "count": len(app.state.ingested)}
 

--- a/publisher/app/ssi/state.py
+++ b/publisher/app/ssi/state.py
@@ -43,14 +43,37 @@ class VerificationRequest:
     result: dict | None = None
 
 
+@dataclass
+class PolicyToken:
+    jti: str
+    token: str
+    dataset_id: str
+    purpose: str
+    holder_did: str | None
+    issued_at: float
+    expires_at: float
+    consumed_at: float | None = None
+
+
 class SSIStateStore:
-    def __init__(self, offer_ttl: int = 600, response_ttl: int = 600) -> None:
+    def __init__(
+        self,
+        offer_ttl: int = 600,
+        response_ttl: int = 600,
+        policy_token_ttl: int = 300,
+    ) -> None:
         self._lock = threading.Lock()
         self._offers: dict[str, Offer] = {}
         self._tokens: dict[str, AccessToken] = {}
         self._requests: dict[str, VerificationRequest] = {}
+        self._policy_tokens: dict[str, PolicyToken] = {}
         self._offer_ttl = offer_ttl
         self._response_ttl = response_ttl
+        self._policy_token_ttl = policy_token_ttl
+
+    @property
+    def policy_token_ttl(self) -> int:
+        return self._policy_token_ttl
 
     # ---- OID4VCI ----
 
@@ -143,3 +166,55 @@ class SSIStateStore:
             req = self._requests.get(state)
             if req:
                 req.result = result
+
+    # ---- PolicyToken ----
+    # TODO: in-memory only; will not survive across publisher replicas.
+    # Move to a shared cache (Redis) or signed JWT before scaling out.
+
+    def create_policy_token(
+        self,
+        *,
+        dataset_id: str,
+        purpose: str,
+        holder_did: str | None,
+    ) -> PolicyToken:
+        now = time.time()
+        pt = PolicyToken(
+            jti=secrets.token_hex(8),
+            token=secrets.token_urlsafe(32),
+            dataset_id=dataset_id,
+            purpose=purpose,
+            holder_did=holder_did,
+            issued_at=now,
+            expires_at=now + self._policy_token_ttl,
+        )
+        with self._lock:
+            self._policy_tokens[pt.token] = pt
+        return pt
+
+    def consume_policy_token(
+        self,
+        token: str,
+        *,
+        dataset_id: str,
+    ) -> tuple[PolicyToken | None, str]:
+        """Return (token, reason). On success reason="ok"; otherwise a short code.
+
+        Reasons: unknown, expired, already_consumed, dataset_mismatch.
+        """
+        with self._lock:
+            pt = self._policy_tokens.get(token)
+            if not pt:
+                return None, "unknown"
+            if time.time() > pt.expires_at:
+                return None, "expired"
+            if pt.consumed_at is not None:
+                return None, "already_consumed"
+            if pt.dataset_id != dataset_id:
+                return None, "dataset_mismatch"
+            pt.consumed_at = time.time()
+            return pt, "ok"
+
+    def get_policy_token(self, token: str) -> PolicyToken | None:
+        with self._lock:
+            return self._policy_tokens.get(token)

--- a/publisher/app/ssi/verifier_routes.py
+++ b/publisher/app/ssi/verifier_routes.py
@@ -333,7 +333,18 @@ def build_router(deps: VerifierDeps) -> APIRouter:
             verified="allow" if verified else "deny",
         )
         if verified:
-            return {"status": "allowed", "dataset_id": req.dataset_id}
+            pt = deps.state.create_policy_token(
+                dataset_id=req.dataset_id,
+                purpose=req.purpose,
+                holder_did=holder_did,
+            )
+            return {
+                "status": "allowed",
+                "dataset_id": req.dataset_id,
+                "policy_token": pt.token,
+                "policy_token_jti": pt.jti,
+                "expires_in": int(pt.expires_at - pt.issued_at),
+            }
         return {"status": "denied", "dataset_id": req.dataset_id, "reason": reason}
 
     @router.get("/verifier/status")

--- a/tests/test_ssi_policy_token.py
+++ b/tests/test_ssi_policy_token.py
@@ -1,0 +1,200 @@
+"""PolicyToken gate on /platform/ingest.
+
+Covers issuance via /verifier/response, single-use consumption, expiry,
+dataset mismatch, and that the legacy header-less path still works.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from publisher.app.ssi.did_jwk import did_jwk_from_public_jwk
+from publisher.app.ssi.keys import private_key_to_jwk, public_jwk_from_private_jwk
+from publisher.app.ssi.sdjwt import _b64u, _es256_sign, _json_bytes
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setenv("SSI_ISSUER_KEY_PATH", str(tmp_path / "issuer_key.jwk.json"))
+    monkeypatch.setenv("SSI_PRESENTATION_DEFS_DIR", str(repo_root / "examples" / "ssi_wallet"))
+    monkeypatch.setenv("SSI_ISSUER_BASE_URL", "http://testserver")
+    monkeypatch.setenv("AUDIT_DB_PATH", str(tmp_path / "audit.db"))
+    monkeypatch.setenv("CONSENT_STORE_PATH", str(tmp_path / "consents.json"))
+    monkeypatch.setenv("PLATFORM_API_URL", "http://testserver/platform/ingest")
+    monkeypatch.setenv("MQTT_BROKER_HOST", "localhost")
+    monkeypatch.setenv("MQTT_TOPICS", "")
+    monkeypatch.setenv("SSI_PEX_SIDECAR_URL", "http://127.0.0.1:1")
+
+    import importlib
+    import publisher.app.main as pm
+    importlib.reload(pm)
+
+    with patch("publisher.app.mqtt_subscriber.MQTTSubscriber.start", lambda self: None), \
+         patch("publisher.app.mqtt_subscriber.MQTTSubscriber.stop", lambda self: None):
+        from fastapi.testclient import TestClient
+        with TestClient(pm.app) as tc:
+            yield tc, pm
+
+
+def _make_holder_key():
+    pk = ec.generate_private_key(ec.SECP256R1())
+    jwk = private_key_to_jwk(pk)
+    pub = public_jwk_from_private_jwk(jwk)
+    did = did_jwk_from_public_jwk(pub)
+    return jwk, pub, did
+
+
+def _proof_jwt(priv, pub, nonce, aud):
+    h = _b64u(_json_bytes({"alg": "ES256", "typ": "openid4vci-proof+jwt", "jwk": pub}))
+    p = _b64u(_json_bytes({"nonce": nonce, "aud": aud, "iat": int(time.time())}))
+    sig = _es256_sign(priv, (h + "." + p).encode("ascii"))
+    return h + "." + p + "." + _b64u(sig)
+
+
+def _submission(pd_id: str, input_desc_id: str) -> dict:
+    return {
+        "id": "sub-" + pd_id,
+        "definition_id": pd_id,
+        "descriptor_map": [{"id": input_desc_id, "format": "vc+sd-jwt", "path": "$"}],
+    }
+
+
+def _issue_policy_token(client, *, dataset_id="home/env/temperature", purpose="research") -> tuple[str, str]:
+    priv, pub, _ = _make_holder_key()
+    offer = client.get(
+        "/issuer/offer",
+        params={"type": "ConsentVC", "dataset_id": dataset_id, "purpose": purpose},
+        headers={"accept": "application/json"},
+    ).json()
+    token = client.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": offer["pre_authorized_code"],
+        },
+    ).json()
+    proof = _proof_jwt(priv, pub, token["c_nonce"], "http://testserver")
+    cred = client.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+        json={"format": "vc+sd-jwt", "proof": {"proof_type": "jwt", "jwt": proof}},
+    ).json()
+    req = client.get(
+        "/verifier/request",
+        params={"dataset_id": dataset_id, "purpose": purpose},
+        headers={"accept": "application/json"},
+    ).json()
+    sub = _submission("consent-temperature", "consent_vc_temperature")
+    r = client.post(
+        "/verifier/response",
+        data={
+            "vp_token": cred["credential"],
+            "presentation_submission": json.dumps(sub),
+            "state": req["state"],
+        },
+    )
+    body = r.json()
+    assert body["status"] == "allowed", body
+    assert "policy_token" in body
+    return body["policy_token"], dataset_id
+
+
+def test_verifier_response_returns_policy_token(client):
+    tc, _ = client
+    token, dataset_id = _issue_policy_token(tc)
+    assert isinstance(token, str) and len(token) > 20
+
+
+def test_ingest_with_valid_token_succeeds(client):
+    tc, _ = client
+    token, dataset_id = _issue_policy_token(tc)
+    r = tc.post(
+        "/platform/ingest",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"dataset_id": dataset_id, "purpose": "research", "value": 21.4},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "received"
+
+    logs = tc.get("/audit/logs?limit=5").json()
+    assert any(
+        log["raw_topic"] == "platform/ingest" and log["action"] == "allow"
+        for log in logs
+    )
+
+
+def test_ingest_token_is_single_use(client):
+    tc, _ = client
+    token, dataset_id = _issue_policy_token(tc)
+    headers = {"Authorization": f"Bearer {token}"}
+    body = {"dataset_id": dataset_id, "purpose": "research", "value": 1}
+
+    assert tc.post("/platform/ingest", headers=headers, json=body).status_code == 200
+    r2 = tc.post("/platform/ingest", headers=headers, json=body)
+    assert r2.status_code == 403
+    assert "already_consumed" in r2.json()["detail"]
+
+
+def test_ingest_unknown_token_rejected(client):
+    tc, _ = client
+    r = tc.post(
+        "/platform/ingest",
+        headers={"Authorization": "Bearer bogus"},
+        json={"dataset_id": "home/env/temperature", "purpose": "research"},
+    )
+    assert r.status_code == 401
+    assert "policy_token_unknown" in r.json()["detail"]
+
+
+def test_ingest_dataset_mismatch_rejected(client):
+    tc, _ = client
+    token, _ = _issue_policy_token(tc, dataset_id="home/env/temperature")
+    r = tc.post(
+        "/platform/ingest",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"dataset_id": "home/env/humidity", "purpose": "research"},
+    )
+    assert r.status_code == 403
+    assert "dataset_mismatch" in r.json()["detail"]
+
+
+def test_ingest_expired_token_rejected(client):
+    tc, pm = client
+    token, dataset_id = _issue_policy_token(tc)
+    pt = pm.ssi_state.get_policy_token(token)
+    assert pt is not None
+    pt.expires_at = time.time() - 1
+    r = tc.post(
+        "/platform/ingest",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"dataset_id": dataset_id, "purpose": "research"},
+    )
+    assert r.status_code == 401
+    assert "policy_token_expired" in r.json()["detail"]
+
+
+def test_ingest_without_header_still_works(client):
+    """Legacy Phase 2 webcam/environment hands-on uses /consents + plain ingest."""
+    tc, _ = client
+    r = tc.post(
+        "/platform/ingest",
+        json={"dataset_id": "home/env/temperature", "value": 1},
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "received"
+
+
+def test_ingest_invalid_auth_scheme_rejected(client):
+    tc, _ = client
+    r = tc.post(
+        "/platform/ingest",
+        headers={"Authorization": "Basic abc"},
+        json={"dataset_id": "home/env/temperature"},
+    )
+    assert r.status_code == 401


### PR DESCRIPTION
## Summary
- Successful `/verifier/response` now mints a short-lived (5 min, single-use) PolicyToken returned in the JSON body
- `/platform/ingest` accepts `Authorization: Bearer <token>` and consumes the PolicyToken; header-less calls retain the legacy `/consents` JSON path used by the existing Phase 2 webcam/environment hands-on
- Both consume success and the four reject reasons (unknown / expired / already_consumed / dataset_mismatch) write audit rows tagged `raw_topic=platform/ingest`

This is Stage 1 of the 4-stage wallet integration roadmap — the OID4VP verification stops being decorative and becomes the actual gate for data sharing.

## Design notes
- PolicyToken is in-memory (TODO comment on SSIStateStore for multi-replica → Redis or signed JWT later)
- Dataset binding: token only authorizes ingest bodies whose `dataset_id` matches the verifier request

## Test plan
- [x] `tests/test_ssi_policy_token.py` — 8 cases: issuance, single-use, expiry, dataset mismatch, unknown token, invalid scheme, header-less passthrough, full /verifier/response → /platform/ingest happy path
- [x] `tests/test_ssi_wallet_flow.py` — existing wallet flow still passes (5 cases)
- [x] Full suite: 18 passed
- [ ] iPhone wallet end-to-end (deferred to user)

## Base branch
Targeting `feat/ssi-wallet-dcql-and-proofs` (PR #10) so the diff is clean against the still-open wallet protocol fix. Rebase onto `main` once #10 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
