### PR TITLE
feat(bridge): scaffold marketplace VC bridge skeleton (v2 / M2 prep)

### DIFF
--- a/bridge/.gitignore
+++ b/bridge/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.log

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install --no-audit --no-fund
+COPY src ./src
+RUN npx tsc
+CMD ["node", "dist/index.js"]

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,0 +1,79 @@
+# bridge — Marketplace VC Bridge service (v2)
+
+Listens to `Merchandise.Purchase` events on the Hardhat chain and
+forwards each purchase to the SSI publisher so the buyer can claim a
+**PurchaseViewerVC**.
+
+## Status
+
+**M2 skeleton.** Not yet wired end-to-end. See the design spec at
+[`iw3ip.github.io/docs/design/marketplace-vc-bridge-spec.md`](https://iw3ip.github.io/design/marketplace-vc-bridge-spec/)
+for the full v1/v2 architecture and milestones.
+
+## Role in v2
+
+```
+Merchandise.Purchase event
+        │
+        ▼
+   bridge (this service)
+        │  POST /marketplace/claim
+        ▼
+   publisher (FastAPI, ssi/)
+        │  OID4VCI offer
+        ▼
+   iw3ip-wallet (PurchaseViewerVC)
+```
+
+v1 (encryptURI → decrypt) keeps running in parallel; bridge does **not**
+modify any on-chain state.
+
+## Layout (planned for M2)
+
+```
+bridge/
+├── README.md              ← this file
+├── package.json           ← Node dependencies (M2)
+├── tsconfig.json
+├── Dockerfile             ← compose-friendly image (M2)
+├── src/
+│   ├── index.ts           ← entrypoint, env loading
+│   ├── listener.ts        ← ethers.js Purchase event subscription
+│   ├── publisher_client.ts ← HTTP client for /marketplace/claim
+│   └── config.ts
+└── test/
+    └── listener.test.ts   ← vitest unit tests with mock Hardhat
+```
+
+## Environment variables
+
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `BRIDGE_HARDHAT_RPC` | `http://hardhat:8545` | RPC endpoint for the local chain |
+| `BRIDGE_IOT_MARKET_ADDRESS` | (required) | `IoTMarket` contract address; bridge enumerates Merchandise from it |
+| `BRIDGE_PUBLISHER_URL` | `http://publisher:8080` | publisher base URL |
+| `BRIDGE_DATASET_DEFAULT` | `home/env/temperature` | fallback `dataset_id` if Merchandise has none |
+
+## Milestones
+
+| ID | Status |
+| --- | --- |
+| M1: design spec | in review |
+| M2: this skeleton + Purchase event → claim API | **here** |
+| M3: PurchaseViewerVC + eth↔did binding | not started |
+| M4: `/platform/data?merchandise=<addr>` + tests | not started |
+| M5: iot-market-ui post-purchase delivery | not started |
+| M6: hands-on docs | not started |
+
+## Running (once M2 lands)
+
+```bash
+docker compose -f infra/docker-compose.yml --profile mv-bridge up --build
+```
+
+## Out of scope for v2 MVP
+
+- EIP-712 signed eth_addr ↔ did:jwk binding (production hardening)
+- KYC / identity-proofing VCs
+- Multi-chain / production RPC
+- Auction / price negotiation

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "iw3ip-mv-bridge",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Marketplace VC Bridge — listens to Merchandise.Purchase and forwards to the SSI publisher (v2 / M2 skeleton)",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "ethers": "^6.13.0",
+    "undici": "^6.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/bridge/src/config.ts
+++ b/bridge/src/config.ts
@@ -1,0 +1,25 @@
+// Bridge runtime config. M2 skeleton — values are env-driven so the
+// service can be dropped into the existing docker compose without
+// hard-coded URLs.
+
+export interface BridgeConfig {
+  hardhatRpc: string;
+  iotMarketAddress: string;
+  publisherUrl: string;
+  datasetDefault: string;
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+export function loadConfig(): BridgeConfig {
+  return {
+    hardhatRpc: process.env.BRIDGE_HARDHAT_RPC ?? "http://hardhat:8545",
+    iotMarketAddress: required("BRIDGE_IOT_MARKET_ADDRESS"),
+    publisherUrl: process.env.BRIDGE_PUBLISHER_URL ?? "http://publisher:8080",
+    datasetDefault: process.env.BRIDGE_DATASET_DEFAULT ?? "home/env/temperature",
+  };
+}

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -1,0 +1,33 @@
+// Bridge service entrypoint. Skeleton only — M2 wires this into
+// docker compose under the `mv-bridge` profile.
+
+import { loadConfig } from "./config.js";
+import { startListener } from "./listener.js";
+import { PublisherClient } from "./publisher_client.js";
+
+async function main() {
+  const cfg = loadConfig();
+  const publisher = new PublisherClient(cfg.publisherUrl);
+  const stop = await startListener({
+    rpcUrl: cfg.hardhatRpc,
+    iotMarketAddress: cfg.iotMarketAddress,
+    datasetDefault: cfg.datasetDefault,
+    publisher,
+  });
+  console.log(
+    `bridge: started rpc=${cfg.hardhatRpc} market=${cfg.iotMarketAddress} publisher=${cfg.publisherUrl}`,
+  );
+
+  const shutdown = () => {
+    console.log("bridge: shutting down");
+    stop();
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+main().catch((e) => {
+  console.error("bridge: fatal", e);
+  process.exit(1);
+});

--- a/bridge/src/listener.ts
+++ b/bridge/src/listener.ts
@@ -1,0 +1,66 @@
+// Hardhat Purchase event listener. Skeleton only — minimal ABI, no
+// retry/backoff yet. M2 lands the full integration.
+
+import { Contract, JsonRpcProvider, type EventLog } from "ethers";
+import type { PublisherClient } from "./publisher_client.js";
+
+const IOT_MARKET_ABI = [
+  "function getMerchandises() view returns (address[])",
+];
+
+const MERCHANDISE_ABI = [
+  "event Purchase(address indexed owner, address indexed buyer, string pubkey)",
+];
+
+export interface ListenerOptions {
+  rpcUrl: string;
+  iotMarketAddress: string;
+  datasetDefault: string;
+  publisher: PublisherClient;
+  log?: (msg: string) => void;
+}
+
+export async function startListener(opts: ListenerOptions): Promise<() => void> {
+  const log = opts.log ?? ((m) => console.log(m));
+  const provider = new JsonRpcProvider(opts.rpcUrl);
+  const market = new Contract(opts.iotMarketAddress, IOT_MARKET_ABI, provider);
+  const merchandises: string[] = await market.getMerchandises();
+  log(`bridge: listening to ${merchandises.length} merchandise(s)`);
+
+  const subs: Array<{ contract: Contract; off: () => void }> = [];
+
+  for (const addr of merchandises) {
+    const contract = new Contract(addr, MERCHANDISE_ABI, provider);
+    const handler = async (
+      _owner: string,
+      buyer: string,
+      _pubkey: string,
+      raw: EventLog,
+    ) => {
+      log(`bridge: Purchase event from ${addr} buyer=${buyer} tx=${raw.transactionHash}`);
+      try {
+        const resp = await opts.publisher.claim({
+          merchandise_address: addr,
+          buyer_eth_addr: buyer,
+          tx_hash: raw.transactionHash,
+          dataset_id: opts.datasetDefault, // TODO M3: read from Merchandise additionalInfo
+          purchase_amount_wei: "0", // TODO M3: read from tx
+        });
+        log(`bridge: claim ok jti=${resp.claim_id} deeplink=${resp.deeplink}`);
+      } catch (e) {
+        log(`bridge: claim failed: ${(e as Error).message}`);
+      }
+    };
+    await contract.on("Purchase", handler);
+    subs.push({
+      contract,
+      off: () => {
+        void contract.off("Purchase", handler);
+      },
+    });
+  }
+
+  return () => {
+    for (const s of subs) s.off();
+  };
+}

--- a/bridge/src/publisher_client.ts
+++ b/bridge/src/publisher_client.ts
@@ -1,0 +1,36 @@
+// HTTP client for the publisher's marketplace endpoints.
+// Skeleton only — wire to real publisher in M2.
+
+import { request } from "undici";
+
+export interface ClaimRequest {
+  merchandise_address: string;
+  buyer_eth_addr: string;
+  tx_hash: string;
+  dataset_id: string;
+  purchase_amount_wei: string;
+}
+
+export interface ClaimResponse {
+  offer_url: string;
+  deeplink: string;
+  claim_id: string;
+}
+
+export class PublisherClient {
+  constructor(private readonly baseUrl: string) {}
+
+  async claim(req: ClaimRequest): Promise<ClaimResponse> {
+    const url = `${this.baseUrl}/marketplace/claim`;
+    const { statusCode, body } = await request(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(req),
+    });
+    const text = await body.text();
+    if (statusCode !== 200) {
+      throw new Error(`publisher /marketplace/claim ${statusCode}: ${text}`);
+    }
+    return JSON.parse(text) as ClaimResponse;
+  }
+}

--- a/bridge/test/publisher_client.test.ts
+++ b/bridge/test/publisher_client.test.ts
@@ -1,0 +1,13 @@
+// Bridge skeleton smoke tests.
+// M2 will replace these with real listener tests once the publisher
+// /marketplace/claim endpoint is implemented.
+
+import { describe, it, expect } from "vitest";
+import { PublisherClient } from "../src/publisher_client.js";
+
+describe("PublisherClient", () => {
+  it("constructs with a base URL", () => {
+    const c = new PublisherClient("http://publisher:8080");
+    expect(c).toBeDefined();
+  });
+});

--- a/bridge/tsconfig.json
+++ b/bridge/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
Scaffolds the empty-but-coherent `bridge/` directory that holds the purchase-event listener and publisher HTTP client for the **Marketplace VC Bridge v2** project. Skeleton only — wiring lands in M2.

Companion to the design spec PR: [ertlnagoya/iw3ip.github.io#8](https://github.com/ertlnagoya/iw3ip.github.io/pull/8) which lays out v1/v2 structure and the M1-M6 milestones.

## What lands in this PR

```
bridge/
├── README.md                    role + milestone status
├── package.json                 ethers v6 + undici + vitest
├── tsconfig.json
├── Dockerfile                   node:22-alpine, compose-friendly
├── .gitignore
├── src/
│   ├── config.ts                env-driven runtime config
│   ├── publisher_client.ts      POST /marketplace/claim client
│   ├── listener.ts              ethers Purchase event subscription
│   └── index.ts                 entrypoint with graceful shutdown
└── test/
    └── publisher_client.test.ts vitest harness placeholder
```

## What this PR does NOT do (by design)

- Does **not** wire `bridge` into `infra/docker-compose.yml` — done in M2
- Does **not** implement publisher's `/marketplace/claim` endpoint — done in M2
- Does **not** issue any PurchaseViewerVC — done in M3
- Does **not** modify any contract or v1 lane

## Out of scope for the v2 MVP (per spec §3.4)

- EIP-712 signed eth_addr ↔ did:jwk binding (production hardening)
- KYC / identity-proofing VCs
- Multi-chain / production RPC
- Auction / price negotiation

## Test plan
- [x] `tsc` builds the skeleton cleanly
- [x] `vitest` runs the placeholder
- [ ] M2 will exercise the listener against a real Hardhat container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
