### PR TITLE
feat(bridge,publisher): /marketplace/claim hand-off (v2 / M2)

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -52,5 +52,23 @@ services:
     depends_on:
       - mosquitto
 
+  bridge:
+    build:
+      context: ../bridge
+      dockerfile: Dockerfile
+    container_name: iw3ip-mv-bridge
+    profiles: ["mv-bridge"]
+    depends_on:
+      - publisher
+    environment:
+      # Hardhat is expected to run on the host (`npx hardhat node`)
+      # so the existing iot-market workflow stays unchanged.
+      BRIDGE_HARDHAT_RPC: ${BRIDGE_HARDHAT_RPC:-http://host.docker.internal:8545}
+      BRIDGE_IOT_MARKET_ADDRESS: ${BRIDGE_IOT_MARKET_ADDRESS:-}
+      BRIDGE_PUBLISHER_URL: http://publisher:8080
+      BRIDGE_DATASET_DEFAULT: ${BRIDGE_DATASET_DEFAULT:-home/env/temperature}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
 volumes:
   publisher_data:

--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -282,3 +282,117 @@ def platform_data(
         "read_count": vt.read_count,
         "rows": rows,
     }
+
+
+# ---- Marketplace VC Bridge (v2 / M2) ----
+# The bridge service POSTs here when a Merchandise.Purchase event fires.
+# We record the (eth_addr, tx_hash, merchandise) context and return an
+# OID4VCI offer URL bound to that context. The actual PurchaseViewerVC
+# type (with merchandise/tx claims) lands in M3; for M2 we return an
+# offer that issues a regular ViewerVC scoped to the dataset.
+
+import json as _json
+import urllib.parse as _urllib
+from publisher.app.ssi.url_utils import externally_reachable_base_url
+from starlette.requests import Request as _Request
+
+
+@app.post("/marketplace/claim")
+def marketplace_claim(body: dict, request: _Request) -> dict:
+    required_fields = (
+        "merchandise_address",
+        "buyer_eth_addr",
+        "tx_hash",
+        "dataset_id",
+    )
+    for f in required_fields:
+        if not body.get(f):
+            raise HTTPException(status_code=400, detail=f"missing_field:{f}")
+
+    claim, created = ssi_state.create_marketplace_claim(
+        merchandise_address=body["merchandise_address"],
+        buyer_eth_addr=body["buyer_eth_addr"],
+        tx_hash=body["tx_hash"],
+        dataset_id=body["dataset_id"],
+        purchase_amount_wei=str(body.get("purchase_amount_wei", "0")),
+    )
+
+    # Stitch the claim's pre_authorized_code into a credential offer that
+    # the publisher's existing /issuer/* path knows how to redeem. M3 will
+    # extend offer creation to fold merchandise context into the issued
+    # PurchaseViewerVC; for now we register the claim's code as a regular
+    # ViewerVC offer for the dataset.
+    if created:
+        # Reserve an Offer entry so /issuer/token can find the
+        # pre_authorized_code we just minted.
+        ssi_state._offers[claim.pre_authorized_code] = (  # noqa: SLF001
+            __import__("publisher.app.ssi.state", fromlist=["Offer"]).Offer(
+                pre_authorized_code=claim.pre_authorized_code,
+                credential_config_id="ViewerVC",  # M3: switch to PurchaseViewerVC
+                dataset_id=claim.dataset_id,
+                purpose="read",
+                allowed_purposes=["read"],
+                created_at=claim.created_at,
+                vc_kind="ViewerVC",  # M3: PurchaseViewerVC
+            )
+        )
+        audit_repo.write(
+            AuditLogRecord(
+                ts=datetime.now(timezone.utc).isoformat(),
+                action="allow",
+                subject_did=f"eth:{claim.buyer_eth_addr}",
+                dataset_id=claim.dataset_id,
+                purpose="purchase",
+                reason=f"claim_received:{claim.claim_id}:tx={claim.tx_hash}",
+                message_hash="",
+                raw_topic="marketplace/claim",
+                holder_did=None,  # M3 fills this in once wallet completes
+                vc_hash=None,
+                presentation_verified="allow",
+            )
+        )
+
+    public_base = externally_reachable_base_url(request, ssi_settings.issuer_base_url)
+    co = {
+        "credential_issuer": public_base,
+        "credential_configuration_ids": ["ViewerVC"],
+        "grants": {
+            "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+                "pre-authorized_code": claim.pre_authorized_code,
+            }
+        },
+    }
+    deeplink = (
+        "openid-credential-offer://?credential_offer="
+        + _urllib.quote(_json.dumps(co, separators=(",", ":")))
+    )
+    offer_url = (
+        f"{public_base}/issuer/offer?type=ViewerVC"
+        f"&dataset_id={_urllib.quote(claim.dataset_id)}&purpose=read"
+        f"&claim_id={claim.claim_id}"
+    )
+    return {
+        "claim_id": claim.claim_id,
+        "offer_url": offer_url,
+        "deeplink": deeplink,
+        "merchandise_address": claim.merchandise_address,
+        "buyer_eth_addr": claim.buyer_eth_addr,
+        "tx_hash": claim.tx_hash,
+        "created": created,
+    }
+
+
+@app.get("/marketplace/claim/{claim_id}")
+def marketplace_claim_status(claim_id: str) -> dict:
+    c = ssi_state.get_marketplace_claim(claim_id)
+    if not c:
+        raise HTTPException(status_code=404, detail="claim_not_found")
+    return {
+        "claim_id": c.claim_id,
+        "merchandise_address": c.merchandise_address,
+        "buyer_eth_addr": c.buyer_eth_addr,
+        "tx_hash": c.tx_hash,
+        "dataset_id": c.dataset_id,
+        "status": "delivered" if c.holder_did else "pending",
+        "holder_did": c.holder_did,
+    }

--- a/publisher/app/ssi/state.py
+++ b/publisher/app/ssi/state.py
@@ -75,6 +75,24 @@ class ViewerToken:
 
 
 @dataclass
+class MarketplaceClaim:
+    """Bridge-recorded purchase context that maps an Ethereum tx to an
+    OID4VCI offer (M2 / v2). M3 grafts the eth_addr <-> did:jwk binding
+    on top by recording the holder_did once the wallet completes
+    credential receipt.
+    """
+    claim_id: str
+    pre_authorized_code: str
+    merchandise_address: str
+    buyer_eth_addr: str
+    tx_hash: str
+    dataset_id: str
+    purchase_amount_wei: str
+    created_at: float
+    holder_did: str | None = None  # filled in M3 once wallet receives the VC
+
+
+@dataclass
 class ServiceToken:
     """M2M write counterpart to PolicyToken (Stage 4 prep).
 
@@ -108,6 +126,8 @@ class SSIStateStore:
         self._policy_tokens: dict[str, PolicyToken] = {}
         self._viewer_tokens: dict[str, ViewerToken] = {}
         self._service_tokens: dict[str, ServiceToken] = {}
+        self._marketplace_claims: dict[str, MarketplaceClaim] = {}
+        self._marketplace_claims_by_tx: dict[str, MarketplaceClaim] = {}
         self._offer_ttl = offer_ttl
         self._response_ttl = response_ttl
         self._policy_token_ttl = policy_token_ttl
@@ -365,3 +385,61 @@ class SSIStateStore:
     def get_service_token(self, token: str) -> ServiceToken | None:
         with self._lock:
             return self._service_tokens.get(token)
+
+    # ---- MarketplaceClaim (v2 / M2) ----
+    # Each Purchase event from the bridge becomes one MarketplaceClaim.
+    # Idempotent on tx_hash: replaying the same Purchase returns the
+    # existing claim instead of double-issuing.
+
+    def create_marketplace_claim(
+        self,
+        *,
+        merchandise_address: str,
+        buyer_eth_addr: str,
+        tx_hash: str,
+        dataset_id: str,
+        purchase_amount_wei: str,
+    ) -> tuple[MarketplaceClaim, bool]:
+        """Return (claim, created). created=False means we returned the
+        previously-recorded claim for this tx_hash (idempotent)."""
+        with self._lock:
+            existing = self._marketplace_claims_by_tx.get(tx_hash)
+            if existing:
+                return existing, False
+            claim = MarketplaceClaim(
+                claim_id=secrets.token_hex(8),
+                pre_authorized_code=secrets.token_urlsafe(24),
+                merchandise_address=merchandise_address,
+                buyer_eth_addr=buyer_eth_addr,
+                tx_hash=tx_hash,
+                dataset_id=dataset_id,
+                purchase_amount_wei=purchase_amount_wei,
+                created_at=time.time(),
+            )
+            self._marketplace_claims[claim.claim_id] = claim
+            self._marketplace_claims_by_tx[tx_hash] = claim
+        return claim, True
+
+    def get_marketplace_claim(self, claim_id: str) -> MarketplaceClaim | None:
+        with self._lock:
+            return self._marketplace_claims.get(claim_id)
+
+    def find_marketplace_claim_by_code(
+        self, pre_authorized_code: str
+    ) -> MarketplaceClaim | None:
+        with self._lock:
+            for c in self._marketplace_claims.values():
+                if c.pre_authorized_code == pre_authorized_code:
+                    return c
+            return None
+
+    def attach_holder_to_claim(
+        self, claim_id: str, holder_did: str
+    ) -> MarketplaceClaim | None:
+        """M3 hook: record eth_addr <-> did:jwk binding once a wallet
+        finishes credential receipt for the claim."""
+        with self._lock:
+            c = self._marketplace_claims.get(claim_id)
+            if c:
+                c.holder_did = holder_did
+            return c

--- a/tests/test_marketplace_claim.py
+++ b/tests/test_marketplace_claim.py
@@ -1,0 +1,144 @@
+"""POST /marketplace/claim contract: bridge -> publisher hand-off.
+
+M2 covers:
+  - new claim creates an Offer reachable via /issuer/token
+  - replaying the same tx_hash is idempotent
+  - missing fields rejected
+  - GET /marketplace/claim/{id} reflects status
+
+PurchaseViewerVC issuance with merchandise/tx claims and the
+eth_addr <-> did:jwk binding land in M3.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setenv("SSI_ISSUER_KEY_PATH", str(tmp_path / "issuer_key.jwk.json"))
+    monkeypatch.setenv("SSI_PRESENTATION_DEFS_DIR", str(repo_root / "examples" / "ssi_wallet"))
+    monkeypatch.setenv("SSI_ISSUER_BASE_URL", "http://testserver")
+    monkeypatch.setenv("AUDIT_DB_PATH", str(tmp_path / "audit.db"))
+    monkeypatch.setenv("CONSENT_STORE_PATH", str(tmp_path / "consents.json"))
+    monkeypatch.setenv("PLATFORM_API_URL", "http://testserver/platform/ingest")
+    monkeypatch.setenv("MQTT_BROKER_HOST", "localhost")
+    monkeypatch.setenv("MQTT_TOPICS", "")
+    monkeypatch.setenv("SSI_PEX_SIDECAR_URL", "http://127.0.0.1:1")
+
+    import importlib
+    import publisher.app.main as pm
+    importlib.reload(pm)
+
+    with patch("publisher.app.mqtt_subscriber.MQTTSubscriber.start", lambda self: None), \
+         patch("publisher.app.mqtt_subscriber.MQTTSubscriber.stop", lambda self: None):
+        from fastapi.testclient import TestClient
+        with TestClient(pm.app) as tc:
+            yield tc, pm
+
+
+_BASE_BODY = {
+    "merchandise_address": "0x0000000000000000000000000000000000000abc",
+    "buyer_eth_addr": "0xdeadbeef00000000000000000000000000000000",
+    "tx_hash": "0xfeedface" + "00" * 28,
+    "dataset_id": "home/env/temperature",
+    "purchase_amount_wei": "10000000000000000",
+}
+
+
+def test_claim_creates_offer_and_returns_deeplink(client):
+    tc, _ = client
+    r = tc.post("/marketplace/claim", json=_BASE_BODY)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["claim_id"]
+    assert body["created"] is True
+    assert body["deeplink"].startswith("openid-credential-offer://")
+    assert body["offer_url"].startswith("http://testserver/issuer/offer")
+    assert body["merchandise_address"] == _BASE_BODY["merchandise_address"]
+    assert body["tx_hash"] == _BASE_BODY["tx_hash"]
+
+
+def test_claim_is_idempotent_on_tx_hash(client):
+    tc, _ = client
+    r1 = tc.post("/marketplace/claim", json=_BASE_BODY).json()
+    r2 = tc.post("/marketplace/claim", json=_BASE_BODY).json()
+    assert r1["claim_id"] == r2["claim_id"]
+    assert r1["deeplink"] == r2["deeplink"]
+    assert r2["created"] is False
+
+
+def test_claim_status_endpoint_reports_pending_until_holder_attaches(client):
+    tc, pm = client
+    body = tc.post("/marketplace/claim", json=_BASE_BODY).json()
+    s1 = tc.get(f"/marketplace/claim/{body['claim_id']}").json()
+    assert s1["status"] == "pending"
+    assert s1["holder_did"] is None
+
+    # Simulate M3 attaching a wallet holder DID
+    pm.ssi_state.attach_holder_to_claim(body["claim_id"], "did:jwk:test-holder")
+    s2 = tc.get(f"/marketplace/claim/{body['claim_id']}").json()
+    assert s2["status"] == "delivered"
+    assert s2["holder_did"] == "did:jwk:test-holder"
+
+
+def test_claim_missing_field_rejected(client):
+    tc, _ = client
+    incomplete = {k: v for k, v in _BASE_BODY.items() if k != "buyer_eth_addr"}
+    r = tc.post("/marketplace/claim", json=incomplete)
+    assert r.status_code == 400
+    assert "missing_field:buyer_eth_addr" in r.json()["detail"]
+
+
+def test_claim_unknown_id_returns_404(client):
+    tc, _ = client
+    r = tc.get("/marketplace/claim/does-not-exist")
+    assert r.status_code == 404
+
+
+def test_claim_audit_log_records_eth_addr_and_tx(client):
+    tc, _ = client
+    body = tc.post("/marketplace/claim", json=_BASE_BODY).json()
+    logs = tc.get("/audit/logs?limit=5").json()
+    matching = [
+        log for log in logs
+        if log["raw_topic"] == "marketplace/claim"
+        and body["claim_id"] in log["reason"]
+    ]
+    assert len(matching) == 1
+    log = matching[0]
+    assert log["action"] == "allow"
+    assert _BASE_BODY["tx_hash"] in log["reason"]
+    assert log["subject_did"] == f"eth:{_BASE_BODY['buyer_eth_addr']}"
+    assert log["dataset_id"] == _BASE_BODY["dataset_id"]
+
+
+def test_claim_offer_redeemable_via_issuer_token(client):
+    """The pre_authorized_code embedded in the deeplink should be
+    accepted by /issuer/token, proving the bridge -> issuer hand-off
+    is wired correctly. Full credential issuance with M3 PurchaseViewerVC
+    claims is exercised separately."""
+    import json as _json
+    import urllib.parse as _urllib
+
+    tc, _ = client
+    body = tc.post("/marketplace/claim", json=_BASE_BODY).json()
+    # Decode the credential_offer query param to extract pre-auth code
+    deeplink = body["deeplink"]
+    qs = deeplink.split("?", 1)[1]
+    co = _json.loads(_urllib.unquote(qs.split("=", 1)[1]))
+    pre_auth = co["grants"]["urn:ietf:params:oauth:grant-type:pre-authorized_code"]["pre-authorized_code"]
+
+    r = tc.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": pre_auth,
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert "access_token" in r.json()


### PR DESCRIPTION
## Summary
**M2 of the Marketplace VC Bridge project.** Implements the bridge → publisher hand-off so a `Merchandise.Purchase` event on Hardhat results in an OID4VCI offer URL the wallet can pick up.

Builds on the bridge skeleton in [#14](https://github.com/ertlnagoya/Blockchain_IoT_Marketplace/pull/14). Followed by M3 (PurchaseViewerVC + eth↔did binding).

Spec: [iw3ip.github.io PR #8](https://github.com/ertlnagoya/iw3ip.github.io/pull/8) (Marketplace VC Bridge v1/v2 spec).

## What lands

### Publisher additions
- **`MarketplaceClaim`** dataclass + idempotent registry on `tx_hash` (replaying the same Purchase returns the existing claim)
- **`POST /marketplace/claim`** — stores the claim, mints a `pre_authorized_code`, returns `{claim_id, offer_url, deeplink, created}`
- **`GET /marketplace/claim/{id}`** — status reports `pending` until M3 wallet receipt attaches a `holder_did`, then `delivered`
- Audit log gains `raw_topic=marketplace/claim` entries with `reason=claim_received:<jti>:tx=<hash>` and `subject_did=eth:<addr>`

### Compose wiring
- New `bridge` service under profile `mv-bridge`
- `depends_on: publisher`, talks to host Hardhat via `host.docker.internal` (matches the existing iot-market workflow without dockerizing Hardhat)

## What this PR does NOT do (deferred to M3)

- **PurchaseViewerVC kind**: the offer currently issues a regular `ViewerVC`; M3 introduces the `PurchaseViewerVC` VCT with `merchandise_address`/`tx_hash`/`buyer_eth_addr` claims
- **eth_addr ↔ did:jwk binding**: `attach_holder_to_claim` exists but is only exercised by tests; M3 calls it from the issuer flow
- **iot-market-ui integration**: M5

## Tests
`tests/test_marketplace_claim.py` (7 new):
- new claim creates an Offer reachable via `/issuer/token`
- replaying `tx_hash` is idempotent
- `/marketplace/claim/{id}` status transitions on holder attach
- missing fields rejected (400)
- unknown id 404
- audit log carries `eth_addr` + `tx_hash`
- the issued pre_auth code redeems against `/issuer/token`

**Suite**: 44 passed (7 new + 37 existing).

## Manual smoke test (Hardhat host-side)

```bash
# 1. Bring up the new bridge profile (no Hardhat in compose; run on host)
docker compose -f infra/docker-compose.yml --profile ssi-wallet --profile mv-bridge up --build -d

# 2. (separate terminal) Run Hardhat + deploy IoTMarket + register a Merchandise
cd iot-market
npx hardhat node
# (then in another terminal) npx hardhat run scripts/deployIoTMarket.ts --network localhost
# Set BRIDGE_IOT_MARKET_ADDRESS in .env so bridge can find merchandises

# 3. Trigger a Purchase (any account paying merchandise.getPrice())
# 4. docker compose logs bridge — should show "Purchase event ... claim ok jti=..."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
