### PR TITLE
feat(ssi,marketplace): PurchaseViewerVC + eth-did binding (v2 / M3)

### DIFF
--- a/examples/ssi_wallet/purchase-viewer-temperature.json
+++ b/examples/ssi_wallet/purchase-viewer-temperature.json
@@ -1,0 +1,42 @@
+{
+  "id": "purchase-viewer-temperature",
+  "name": "PurchaseViewer VC for home/env/temperature",
+  "purpose": "Verify the wallet holds a PurchaseViewerVC bound to a Merchandise.Purchase tx for temperature data.",
+  "iw3ip_dataset_id": "home/env/temperature",
+  "iw3ip_vc_kind": "PurchaseViewerVC",
+  "input_descriptors": [
+    {
+      "id": "purchase_viewer_vc_temperature",
+      "name": "PurchaseViewerVC (temperature)",
+      "format": {
+        "vc+sd-jwt": {
+          "sd-jwt_alg_values": ["ES256"],
+          "kb-jwt_alg_values": ["ES256"]
+        }
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": ["$.vct"],
+            "filter": {
+              "type": "string",
+              "const": "https://iw3ip.example/credentials/PurchaseViewerVC/v1"
+            }
+          },
+          {
+            "path": ["$.dataset_id"],
+            "filter": {
+              "type": "string",
+              "const": "home/env/temperature"
+            }
+          },
+          { "path": ["$.allowed_actions"], "filter": { "type": "array" } },
+          { "path": ["$.merchandise_address"], "filter": { "type": "string" } },
+          { "path": ["$.buyer_eth_addr"], "filter": { "type": "string" } },
+          { "path": ["$.tx_hash"], "filter": { "type": "string" } },
+          { "path": ["$.subject_id"] }
+        ]
+      }
+    }
+  ]
+}

--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -82,7 +82,8 @@ ssi_pex_client = PEXSidecarClient(ssi_settings.pex_sidecar_url)
 app.include_router(
     issuer_routes.build_router(
         issuer_routes.IssuerDeps(
-            settings=ssi_settings, keys=ssi_keys, state=ssi_state
+            settings=ssi_settings, keys=ssi_keys, state=ssi_state,
+            audit_repo=audit_repo,
         )
     )
 )
@@ -324,16 +325,17 @@ def marketplace_claim(body: dict, request: _Request) -> dict:
     # ViewerVC offer for the dataset.
     if created:
         # Reserve an Offer entry so /issuer/token can find the
-        # pre_authorized_code we just minted.
+        # pre_authorized_code we just minted. M3: PurchaseViewerVC
+        # binds merchandise + tx + buyer_eth_addr to the issued credential.
         ssi_state._offers[claim.pre_authorized_code] = (  # noqa: SLF001
             __import__("publisher.app.ssi.state", fromlist=["Offer"]).Offer(
                 pre_authorized_code=claim.pre_authorized_code,
-                credential_config_id="ViewerVC",  # M3: switch to PurchaseViewerVC
+                credential_config_id="PurchaseViewerVC",
                 dataset_id=claim.dataset_id,
                 purpose="read",
                 allowed_purposes=["read"],
                 created_at=claim.created_at,
-                vc_kind="ViewerVC",  # M3: PurchaseViewerVC
+                vc_kind="PurchaseViewerVC",
             )
         )
         audit_repo.write(
@@ -355,7 +357,7 @@ def marketplace_claim(body: dict, request: _Request) -> dict:
     public_base = externally_reachable_base_url(request, ssi_settings.issuer_base_url)
     co = {
         "credential_issuer": public_base,
-        "credential_configuration_ids": ["ViewerVC"],
+        "credential_configuration_ids": ["PurchaseViewerVC"],
         "grants": {
             "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
                 "pre-authorized_code": claim.pre_authorized_code,
@@ -367,7 +369,7 @@ def marketplace_claim(body: dict, request: _Request) -> dict:
         + _urllib.quote(_json.dumps(co, separators=(",", ":")))
     )
     offer_url = (
-        f"{public_base}/issuer/offer?type=ViewerVC"
+        f"{public_base}/issuer/offer?type=PurchaseViewerVC"
         f"&dataset_id={_urllib.quote(claim.dataset_id)}&purpose=read"
         f"&claim_id={claim.claim_id}"
     )

--- a/publisher/app/ssi/issuer_routes.py
+++ b/publisher/app/ssi/issuer_routes.py
@@ -4,10 +4,13 @@ import json
 import time
 import urllib.parse
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Form, Header, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
+from audit.models import AuditLogRecord
+from audit.repository import SQLiteAuditRepository
 from publisher.app.ssi.config import SSISettings
 from publisher.app.ssi.did_jwk import did_jwk_from_public_jwk, public_jwk_from_did_jwk
 from publisher.app.ssi.html import render_qr_page
@@ -23,23 +26,29 @@ VIEWER_VC_CONFIG_ID = "ViewerVC"
 VIEWER_VCT = "https://iw3ip.example/credentials/ViewerVC/v1"
 SERVICE_VC_CONFIG_ID = "ServiceVC"
 SERVICE_VCT = "https://iw3ip.example/credentials/ServiceVC/v1"
+PURCHASE_VIEWER_VC_CONFIG_ID = "PurchaseViewerVC"
+PURCHASE_VIEWER_VCT = "https://iw3ip.example/credentials/PurchaseViewerVC/v1"
 
 # Backwards-compatible aliases for code/tests that imported the originals.
 CREDENTIAL_CONFIG_ID = CONSENT_VC_CONFIG_ID
 VCT = CONSENT_VCT
 
-# ConsentVC = single-use write authz (Stage 1)
-# ViewerVC  = multi-use read authz   (Stage 3)
-# ServiceVC = multi-use write authz  (Stage 4 prep, M2M)
+# ConsentVC         = single-use write authz       (Stage 1)
+# ViewerVC          = multi-use read authz         (Stage 3)
+# ServiceVC         = multi-use write authz, M2M   (Stage 4 prep)
+# PurchaseViewerVC  = read authz tied to a Merchandise.Purchase tx
+#                     (v2 / Stage 5, marketplace bridge)
 VC_KIND_TO_VCT = {
     "ConsentVC": CONSENT_VCT,
     "ViewerVC": VIEWER_VCT,
     "ServiceVC": SERVICE_VCT,
+    "PurchaseViewerVC": PURCHASE_VIEWER_VCT,
 }
 VC_KIND_TO_CONFIG_ID = {
     "ConsentVC": CONSENT_VC_CONFIG_ID,
     "ViewerVC": VIEWER_VC_CONFIG_ID,
     "ServiceVC": SERVICE_VC_CONFIG_ID,
+    "PurchaseViewerVC": PURCHASE_VIEWER_VC_CONFIG_ID,
 }
 
 DEEPLINK_SCHEME = "openid-credential-offer://"
@@ -58,6 +67,7 @@ class IssuerDeps:
     settings: SSISettings
     keys: IssuerKeyStore
     state: SSIStateStore
+    audit_repo: SQLiteAuditRepository | None = None  # M3: required for PurchaseViewerVC
 
 
 def _issuer_did(keys: IssuerKeyStore) -> str:
@@ -134,6 +144,24 @@ def _credential_issuer_metadata(base_url: str, keys: IssuerKeyStore) -> dict:
                 "claims": {
                     "dataset_id": {"display": [{"name": "Dataset ID"}]},
                     "allowed_actions": {"display": [{"name": "Allowed actions"}]},
+                    "subject_id": {"display": [{"name": "Subject"}], "mandatory": False},
+                    "iw3ip_issuer": {"display": [{"name": "Issuer"}]},
+                },
+            },
+            PURCHASE_VIEWER_VC_CONFIG_ID: {
+                **common_alg,
+                "vct": PURCHASE_VIEWER_VCT,
+                "scope": "PurchaseViewerVC",
+                "display": [
+                    {"name": "IW3IP Purchase Viewer Credential", "locale": "en"},
+                    {"name": "IW3IP 購入閲覧クレデンシャル", "locale": "ja"},
+                ],
+                "claims": {
+                    "dataset_id": {"display": [{"name": "Dataset ID"}]},
+                    "allowed_actions": {"display": [{"name": "Allowed actions"}]},
+                    "merchandise_address": {"display": [{"name": "Merchandise contract"}]},
+                    "buyer_eth_addr": {"display": [{"name": "Buyer ETH address"}]},
+                    "tx_hash": {"display": [{"name": "Purchase tx hash"}]},
                     "subject_id": {"display": [{"name": "Subject"}], "mandatory": False},
                     "iw3ip_issuer": {"display": [{"name": "Issuer"}]},
                 },
@@ -219,9 +247,14 @@ def build_router(deps: IssuerDeps) -> APIRouter:
         elif type == "ViewerVC":
             allowed = ["read"]
             page_title = "IW3IP Viewer VC を発行"
-        else:  # ServiceVC: M2M write authz
+        elif type == "ServiceVC":
             allowed = ["write_continuous"]
             page_title = "IW3IP Service VC を発行"
+        else:  # PurchaseViewerVC: bridge issues these via /marketplace/claim,
+            # not directly via /issuer/offer. We still support the manual path
+            # for hands-on debugging.
+            allowed = ["read"]
+            page_title = "IW3IP Purchase Viewer VC を発行"
 
         offer = deps.state.create_offer(
             credential_config_id=config_id,
@@ -332,7 +365,46 @@ def build_router(deps: IssuerDeps) -> APIRouter:
         issuer_did = _issuer_did(deps.keys)
         holder_did = did_jwk_from_public_jwk(holder_jwk)
 
-        if offer.vc_kind in ("ViewerVC", "ServiceVC"):
+        if offer.vc_kind == "PurchaseViewerVC":
+            # M3: fold marketplace context into the claims and link the
+            # holder DID back to the bridge-recorded claim.
+            claim = deps.state.find_marketplace_claim_by_code(
+                offer.pre_authorized_code
+            )
+            plain_claims = {
+                "dataset_id": offer.dataset_id,
+                "allowed_actions": offer.allowed_purposes,
+                "iw3ip_issuer": deps.settings.issuer_id,
+            }
+            if claim:
+                plain_claims.update({
+                    "merchandise_address": claim.merchandise_address,
+                    "buyer_eth_addr": claim.buyer_eth_addr,
+                    "tx_hash": claim.tx_hash,
+                    "purchased_at": int(claim.created_at),
+                })
+                deps.state.attach_holder_to_claim(claim.claim_id, holder_did)
+                # Audit the eth_addr <-> did:jwk binding now that we have both.
+                if deps.audit_repo is not None:
+                    deps.audit_repo.write(
+                        AuditLogRecord(
+                            ts=datetime.now(timezone.utc).isoformat(),
+                            action="allow",
+                            subject_did=holder_did,
+                            dataset_id=claim.dataset_id,
+                            purpose="purchase_link",
+                            reason=(
+                                f"eth_did_bound:claim={claim.claim_id}"
+                                f":eth={claim.buyer_eth_addr}:tx={claim.tx_hash}"
+                            ),
+                            message_hash="",
+                            raw_topic="marketplace/issued",
+                            holder_did=holder_did,
+                            vc_hash=None,
+                            presentation_verified="allow",
+                        )
+                    )
+        elif offer.vc_kind in ("ViewerVC", "ServiceVC"):
             plain_claims = {
                 "dataset_id": offer.dataset_id,
                 "allowed_actions": offer.allowed_purposes,

--- a/publisher/app/ssi/verifier_routes.py
+++ b/publisher/app/ssi/verifier_routes.py
@@ -142,7 +142,7 @@ def _local_pex_fallback(
     # enforce request-time purpose/dataset
     if claims.get("dataset_id") != dataset_id:
         return {"verified": False, "reason": "dataset_mismatch", "claims": claims, "holder_did": None}
-    if vc_kind == "ViewerVC":
+    if vc_kind in ("ViewerVC", "PurchaseViewerVC"):
         actions = claims.get("allowed_actions", [])
         if "read" not in actions:
             return {"verified": False, "reason": "action_not_allowed", "claims": claims, "holder_did": None}
@@ -190,7 +190,7 @@ def build_router(deps: VerifierDeps) -> APIRouter:
         purpose: str = Query("read"),
         vc_kind: str = Query("ConsentVC"),
     ):
-        if vc_kind not in ("ConsentVC", "ViewerVC", "ServiceVC"):
+        if vc_kind not in ("ConsentVC", "ViewerVC", "ServiceVC", "PurchaseViewerVC"):
             raise HTTPException(status_code=400, detail=f"unknown vc_kind: {vc_kind}")
         match = deps.definitions.find_for_dataset(dataset_id, vc_kind=vc_kind)
         if not match:
@@ -228,6 +228,7 @@ def build_router(deps: VerifierDeps) -> APIRouter:
         title = {
             "ViewerVC": "IW3IP Viewer VC を提示",
             "ServiceVC": "IW3IP Service VC を提示",
+            "PurchaseViewerVC": "IW3IP Purchase Viewer VC を提示",
         }.get(vc_kind, "IW3IP Consent VC を提示")
         html = render_qr_page(
             title=title,
@@ -274,6 +275,24 @@ def build_router(deps: VerifierDeps) -> APIRouter:
                         "claims": [
                             {"path": ["dataset_id"], "values": [req.dataset_id]},
                             {"path": ["allowed_actions"]},
+                            {"path": ["subject_id"]},
+                        ],
+                    }
+                ]
+            }
+        elif req.vc_kind == "PurchaseViewerVC":
+            dcql = {
+                "credentials": [
+                    {
+                        "id": "purchase_viewer_vc",
+                        "format": "dc+sd-jwt",
+                        "meta": {"vct_values": ["https://iw3ip.example/credentials/PurchaseViewerVC/v1"]},
+                        "claims": [
+                            {"path": ["dataset_id"], "values": [req.dataset_id]},
+                            {"path": ["allowed_actions"]},
+                            {"path": ["merchandise_address"]},
+                            {"path": ["buyer_eth_addr"]},
+                            {"path": ["tx_hash"]},
                             {"path": ["subject_id"]},
                         ],
                     }
@@ -362,7 +381,7 @@ def build_router(deps: VerifierDeps) -> APIRouter:
             if claims.get("dataset_id") not in (None, req.dataset_id):
                 verified = False
                 reason = "dataset_mismatch"
-            elif req.vc_kind == "ViewerVC":
+            elif req.vc_kind in ("ViewerVC", "PurchaseViewerVC"):
                 actions = claims.get("allowed_actions")
                 if actions is not None and "read" not in actions:
                     verified = False
@@ -392,24 +411,32 @@ def build_router(deps: VerifierDeps) -> APIRouter:
             verified="allow" if verified else "deny",
         )
         if verified:
-            if req.vc_kind == "ViewerVC":
+            if req.vc_kind in ("ViewerVC", "PurchaseViewerVC"):
                 vt = deps.state.create_viewer_token(
                     dataset_id=req.dataset_id,
                     holder_did=holder_did,
                 )
                 logger.info(
-                    "viewer_token_issued jti=%s token=%s dataset=%s ttl=%ss",
-                    vt.jti, vt.token, vt.dataset_id,
+                    "viewer_token_issued vc_kind=%s jti=%s token=%s dataset=%s ttl=%ss",
+                    req.vc_kind, vt.jti, vt.token, vt.dataset_id,
                     int(vt.expires_at - vt.issued_at),
                 )
-                return {
+                resp: dict = {
                     "status": "allowed",
                     "dataset_id": req.dataset_id,
-                    "vc_kind": "ViewerVC",
+                    "vc_kind": req.vc_kind,
                     "viewer_token": vt.token,
                     "viewer_token_jti": vt.jti,
                     "expires_in": int(vt.expires_at - vt.issued_at),
                 }
+                # Surface marketplace context in the response so the
+                # iot-market-ui flow (M5) can correlate without re-decoding
+                # the VC.
+                if req.vc_kind == "PurchaseViewerVC":
+                    for k in ("merchandise_address", "buyer_eth_addr", "tx_hash"):
+                        if claims.get(k) is not None:
+                            resp[k] = claims[k]
+                return resp
             if req.vc_kind == "ServiceVC":
                 st = deps.state.create_service_token(
                     dataset_id=req.dataset_id,

--- a/tests/test_marketplace_purchase_vc.py
+++ b/tests/test_marketplace_purchase_vc.py
@@ -1,0 +1,257 @@
+"""End-to-end /marketplace/claim → PurchaseViewerVC → ViewerToken (M3).
+
+Exercises the v2 lane:
+  bridge POSTs claim -> publisher mints offer -> wallet completes
+  OID4VCI -> publisher records eth_addr <-> did:jwk binding -> wallet
+  presents PurchaseViewerVC -> ViewerToken -> /platform/data.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from publisher.app.ssi.did_jwk import did_jwk_from_public_jwk
+from publisher.app.ssi.keys import private_key_to_jwk, public_jwk_from_private_jwk
+from publisher.app.ssi.sdjwt import _b64u, _es256_sign, _json_bytes
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setenv("SSI_ISSUER_KEY_PATH", str(tmp_path / "issuer_key.jwk.json"))
+    monkeypatch.setenv("SSI_PRESENTATION_DEFS_DIR", str(repo_root / "examples" / "ssi_wallet"))
+    monkeypatch.setenv("SSI_ISSUER_BASE_URL", "http://testserver")
+    monkeypatch.setenv("AUDIT_DB_PATH", str(tmp_path / "audit.db"))
+    monkeypatch.setenv("CONSENT_STORE_PATH", str(tmp_path / "consents.json"))
+    monkeypatch.setenv("PLATFORM_API_URL", "http://testserver/platform/ingest")
+    monkeypatch.setenv("MQTT_BROKER_HOST", "localhost")
+    monkeypatch.setenv("MQTT_TOPICS", "")
+    monkeypatch.setenv("SSI_PEX_SIDECAR_URL", "http://127.0.0.1:1")
+
+    import importlib
+    import publisher.app.main as pm
+    importlib.reload(pm)
+
+    with patch("publisher.app.mqtt_subscriber.MQTTSubscriber.start", lambda self: None), \
+         patch("publisher.app.mqtt_subscriber.MQTTSubscriber.stop", lambda self: None):
+        from fastapi.testclient import TestClient
+        with TestClient(pm.app) as tc:
+            yield tc, pm
+
+
+_BASE_BODY = {
+    "merchandise_address": "0x0000000000000000000000000000000000000abc",
+    "buyer_eth_addr": "0xdeadbeef00000000000000000000000000000000",
+    "tx_hash": "0xfeedface" + "00" * 28,
+    "dataset_id": "home/env/temperature",
+    "purchase_amount_wei": "10000000000000000",
+}
+
+
+def _make_holder():
+    pk = ec.generate_private_key(ec.SECP256R1())
+    jwk = private_key_to_jwk(pk)
+    pub = public_jwk_from_private_jwk(jwk)
+    return jwk, pub, did_jwk_from_public_jwk(pub)
+
+
+def _proof_jwt(priv, pub, nonce, aud):
+    h = _b64u(_json_bytes({"alg": "ES256", "typ": "openid4vci-proof+jwt", "jwk": pub}))
+    p = _b64u(_json_bytes({"nonce": nonce, "aud": aud, "iat": int(time.time())}))
+    sig = _es256_sign(priv, (h + "." + p).encode("ascii"))
+    return h + "." + p + "." + _b64u(sig)
+
+
+def _submission(pd_id: str, input_desc_id: str) -> dict:
+    return {
+        "id": "sub-" + pd_id,
+        "definition_id": pd_id,
+        "descriptor_map": [{"id": input_desc_id, "format": "vc+sd-jwt", "path": "$"}],
+    }
+
+
+def _claim_to_pre_auth(deeplink: str) -> str:
+    import urllib.parse as _u
+    qs = deeplink.split("?", 1)[1]
+    co = json.loads(_u.unquote(qs.split("=", 1)[1]))
+    return co["grants"]["urn:ietf:params:oauth:grant-type:pre-authorized_code"]["pre-authorized_code"]
+
+
+def _full_purchase_to_credential(tc) -> tuple[str, str, dict]:
+    """Returns (sd_jwt_vc, holder_did, claim_response)."""
+    claim_resp = tc.post("/marketplace/claim", json=_BASE_BODY).json()
+    pre_auth = _claim_to_pre_auth(claim_resp["deeplink"])
+
+    priv, pub, holder_did = _make_holder()
+    token = tc.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": pre_auth,
+        },
+    ).json()
+    proof = _proof_jwt(priv, pub, token["c_nonce"], "http://testserver")
+    cred = tc.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+        json={
+            "format": "vc+sd-jwt",
+            "vct": "https://iw3ip.example/credentials/PurchaseViewerVC/v1",
+            "proof": {"proof_type": "jwt", "jwt": proof},
+        },
+    ).json()
+    return cred["credential"], holder_did, claim_resp
+
+
+def test_issuer_metadata_lists_purchase_viewer_vc(client):
+    tc, _ = client
+    cfgs = tc.get("/.well-known/openid-credential-issuer").json()["credential_configurations_supported"]
+    assert "PurchaseViewerVC" in cfgs
+    assert cfgs["PurchaseViewerVC"]["vct"].endswith("/PurchaseViewerVC/v1")
+
+
+def test_claim_offer_now_targets_purchase_viewer_vc(client):
+    tc, _ = client
+    body = tc.post("/marketplace/claim", json=_BASE_BODY).json()
+    assert "PurchaseViewerVC" in body["offer_url"]
+
+
+def test_credential_issued_with_marketplace_claims(client):
+    tc, _ = client
+    sd_jwt, holder_did, claim = _full_purchase_to_credential(tc)
+    # Decode the SD-JWT VC payload and verify the claims got injected.
+    head, payload_b64, *_ = sd_jwt.split(".")
+    import base64 as _b64
+    pad = "=" * (-len(payload_b64) % 4)
+    payload = json.loads(_b64.urlsafe_b64decode(payload_b64 + pad))
+    assert payload["dataset_id"] == _BASE_BODY["dataset_id"]
+    assert payload["merchandise_address"] == _BASE_BODY["merchandise_address"]
+    assert payload["buyer_eth_addr"] == _BASE_BODY["buyer_eth_addr"]
+    assert payload["tx_hash"] == _BASE_BODY["tx_hash"]
+    assert "read" in payload["allowed_actions"]
+
+
+def test_eth_did_binding_audited_on_credential_receipt(client):
+    tc, pm = client
+    _, holder_did, claim_resp = _full_purchase_to_credential(tc)
+
+    # Audit log should now carry the eth_did_bound entry.
+    logs = tc.get("/audit/logs?limit=20").json()
+    bound = [
+        log for log in logs
+        if log["raw_topic"] == "marketplace/issued"
+        and log["reason"].startswith("eth_did_bound:")
+    ]
+    assert len(bound) == 1
+    log = bound[0]
+    assert log["holder_did"] == holder_did
+    assert _BASE_BODY["buyer_eth_addr"] in log["reason"]
+    assert _BASE_BODY["tx_hash"] in log["reason"]
+
+    # /marketplace/claim/{id} now reports delivered with the holder DID.
+    status = tc.get(f"/marketplace/claim/{claim_resp['claim_id']}").json()
+    assert status["status"] == "delivered"
+    assert status["holder_did"] == holder_did
+
+
+def test_presentation_yields_viewer_token_with_marketplace_context(client):
+    tc, _ = client
+    sd_jwt, _, _ = _full_purchase_to_credential(tc)
+
+    req = tc.get(
+        "/verifier/request",
+        params={"dataset_id": _BASE_BODY["dataset_id"], "vc_kind": "PurchaseViewerVC"},
+        headers={"accept": "application/json"},
+    ).json()
+    sub = _submission("purchase-viewer-temperature", "purchase_viewer_vc_temperature")
+    body = tc.post(
+        "/verifier/response",
+        data={
+            "vp_token": sd_jwt,
+            "presentation_submission": json.dumps(sub),
+            "state": req["state"],
+        },
+    ).json()
+    assert body["status"] == "allowed", body
+    assert body["vc_kind"] == "PurchaseViewerVC"
+    assert "viewer_token" in body
+    assert body["merchandise_address"] == _BASE_BODY["merchandise_address"]
+    assert body["tx_hash"] == _BASE_BODY["tx_hash"]
+    assert body["buyer_eth_addr"] == _BASE_BODY["buyer_eth_addr"]
+
+
+def test_viewer_token_from_purchase_unlocks_platform_data(client):
+    tc, _ = client
+    sd_jwt, _, _ = _full_purchase_to_credential(tc)
+
+    req = tc.get(
+        "/verifier/request",
+        params={"dataset_id": _BASE_BODY["dataset_id"], "vc_kind": "PurchaseViewerVC"},
+        headers={"accept": "application/json"},
+    ).json()
+    sub = _submission("purchase-viewer-temperature", "purchase_viewer_vc_temperature")
+    body = tc.post(
+        "/verifier/response",
+        data={
+            "vp_token": sd_jwt,
+            "presentation_submission": json.dumps(sub),
+            "state": req["state"],
+        },
+    ).json()
+    viewer_token = body["viewer_token"]
+
+    r = tc.get(
+        "/platform/data",
+        params={"dataset_id": _BASE_BODY["dataset_id"]},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["read_count"] == 1
+
+
+def test_existing_viewer_vc_flow_unaffected(client):
+    """Stage 3 ViewerVC presentation must keep working alongside the v2 path."""
+    tc, _ = client
+    priv, pub, _ = _make_holder()
+    offer = tc.get(
+        "/issuer/offer",
+        params={"type": "ViewerVC", "dataset_id": _BASE_BODY["dataset_id"], "purpose": "read"},
+        headers={"accept": "application/json"},
+    ).json()
+    token = tc.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": offer["pre_authorized_code"],
+        },
+    ).json()
+    proof = _proof_jwt(priv, pub, token["c_nonce"], "http://testserver")
+    cred = tc.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+        json={"format": "vc+sd-jwt",
+              "vct": "https://iw3ip.example/credentials/ViewerVC/v1",
+              "proof": {"proof_type": "jwt", "jwt": proof}},
+    ).json()
+    req = tc.get(
+        "/verifier/request",
+        params={"dataset_id": _BASE_BODY["dataset_id"], "vc_kind": "ViewerVC"},
+        headers={"accept": "application/json"},
+    ).json()
+    sub = _submission("viewer-temperature", "viewer_vc_temperature")
+    body = tc.post(
+        "/verifier/response",
+        data={
+            "vp_token": cred["credential"],
+            "presentation_submission": json.dumps(sub),
+            "state": req["state"],
+        },
+    ).json()
+    assert body["status"] == "allowed"
+    assert body["vc_kind"] == "ViewerVC"
+    assert "merchandise_address" not in body  # only PurchaseViewerVC carries this


### PR DESCRIPTION
## Summary
**M3 of the Marketplace VC Bridge project.** Adds the fourth VC kind so a buyer's wallet, after a `Merchandise.Purchase`, holds a credential whose claims tie back to the on-chain purchase: `merchandise_address`, `tx_hash`, `buyer_eth_addr`, plus the `dataset_id` read scope.

Spec: [iw3ip.github.io#8](https://github.com/ertlnagoya/iw3ip.github.io/pull/8) (merged). Built on M2 ([#15](https://github.com/ertlnagoya/Blockchain_IoT_Marketplace/pull/15)).

## What lands

### Publisher
- **`PurchaseViewerVC`** — 4th VC kind alongside `ConsentVC` / `ViewerVC` / `ServiceVC`
  - VCT: `https://iw3ip.example/credentials/PurchaseViewerVC/v1`
  - Claims: `dataset_id`, `allowed_actions=[read]`, `merchandise_address`, `buyer_eth_addr`, `tx_hash`, `purchased_at`
- **issuer credential pipeline** injects marketplace context from the bridge-recorded `MarketplaceClaim` into the issued VC
- **eth_addr ↔ did:jwk binding**: holder DID is attached to the claim on credential receipt and audit-logged as `raw_topic=marketplace/issued` with `reason=eth_did_bound:claim=<id>:eth=<addr>:tx=<hash>`
- **verifier** accepts `vc_kind=PurchaseViewerVC`, builds a DCQL query requesting the merchandise/tx/eth claims, and yields a regular `ViewerToken` on success
- **`/verifier/response`** surfaces marketplace context fields in the response so iot-market-ui (M5) can correlate without re-decoding the VC
- **`/marketplace/claim`** now mints a PurchaseViewerVC offer (was `ViewerVC` in M2)
- **`GET /marketplace/claim/{id}`** reports `delivered` once the wallet completes credential receipt
- IssuerDeps gains an optional `audit_repo`; wired in `main.py`

### Example PD
`examples/ssi_wallet/purchase-viewer-temperature.json`

## Tests (7 new, all green)
- issuer metadata lists `PurchaseViewerVC`
- claim offer URL targets `PurchaseViewerVC` (was `ViewerVC` in M2)
- issued VC payload carries merchandise/tx/eth claims
- `eth_did_bound` audit entry recorded on credential receipt
- claim status transitions to `delivered` with `holder_did` set
- presentation yields ViewerToken with marketplace context surfaced
- ViewerToken from PurchaseViewerVC unlocks `/platform/data`
- existing Stage 3 ViewerVC flow keeps working (regression)

**Suite**: 51 passed (7 new + 44 existing).

## What this PR does NOT do (deferred)

- **`GET /platform/data?merchandise=<addr>`** (M4) — only `?dataset_id=` for now
- **iot-market-ui post-purchase QR** (M5)
- **Hands-on docs** (M6)

## Audit log shape (after M3)

For one purchase you now get three rows with merchandise context:

```
raw_topic=marketplace/claim    reason=claim_received:<id>:tx=<hash>     subject=eth:0x...
raw_topic=marketplace/issued   reason=eth_did_bound:claim=<id>:eth=...:tx=...  holder_did=did:jwk:...
raw_topic=oid4vp/response      reason=ok                                  presentation_verified=allow
raw_topic=platform/data        reason=viewer_token_used:<jti>:1           holder_did=did:jwk:...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
