### PR TITLE
feat(publisher,ui): /platform/data?merchandise + post-purchase delivery (v2 M4+M5)

### DIFF
--- a/iot-market-ui/src/routes/merchandise/[address]/+page.svelte
+++ b/iot-market-ui/src/routes/merchandise/[address]/+page.svelte
@@ -32,9 +32,20 @@
 					value: ethers.parseEther(data.price)
 				});
 				purchaseStatus = transactionResponse.wait(1);
-				await purchaseStatus;
-				alert('Purchased is Confirmed!\nWe will reload the page to update the status');
-				location.reload();
+				const receipt = await purchaseStatus;
+				const buyer = await signer.getAddress();
+				const txHash = receipt?.hash ?? transactionResponse.hash;
+				// v2 / Stage 5: redirect to the post-purchase VC delivery
+				// page, which calls publisher /marketplace/claim and shows
+				// the OID4VCI deeplink + QR for the wallet to receive a
+				// PurchaseViewerVC. Hand-off is idempotent on tx_hash.
+				const dataset = data.datasetId ?? 'home/env/temperature';
+				const params = new URLSearchParams({
+					merchandise: data.address,
+					dataset,
+					buyer
+				});
+				window.location.href = `/purchased/${txHash}?${params.toString()}`;
 			} catch (err: unknown) {
 				throw new Error((err as Error).message);
 			}

--- a/iot-market-ui/src/routes/purchased/[txHash]/+page.svelte
+++ b/iot-market-ui/src/routes/purchased/[txHash]/+page.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+  // M5: post-purchase VC delivery page (Marketplace VC Bridge v2).
+  //
+  // After a successful Merchandise.purchase() the buyer lands here.
+  // We POST to the publisher's /marketplace/claim endpoint (idempotent
+  // on tx_hash so the bridge can race us harmlessly) and surface the
+  // resulting OID4VCI deeplink as a clickable button + QR code.
+  //
+  // The wallet receives the PurchaseViewerVC, which carries the
+  // merchandise_address / tx_hash / buyer_eth_addr claims. After
+  // presentation the buyer can fetch data via
+  // /platform/data?merchandise=<addr> (covered in M6 hands-on).
+
+  import { page } from '$app/stores';
+  import { onMount } from 'svelte';
+
+  // URL: /purchased/[txHash]?merchandise=0x...&dataset=home/env/temperature&buyer=0x...
+  $: txHash = $page.params.txHash;
+  $: merchandiseAddr = $page.url.searchParams.get('merchandise') ?? '';
+  $: datasetId = $page.url.searchParams.get('dataset') ?? 'home/env/temperature';
+  $: buyerAddr = $page.url.searchParams.get('buyer') ?? '';
+
+  const PUBLISHER_BASE =
+    import.meta.env.VITE_PUBLISHER_URL ?? 'http://localhost:8080';
+
+  let status: 'idle' | 'claiming' | 'ready' | 'error' = 'idle';
+  let errorMsg = '';
+  let deeplink = '';
+  let offerUrl = '';
+  let claimId = '';
+
+  async function postClaim() {
+    status = 'claiming';
+    errorMsg = '';
+    try {
+      const res = await fetch(`${PUBLISHER_BASE}/marketplace/claim`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          merchandise_address: merchandiseAddr,
+          buyer_eth_addr: buyerAddr,
+          tx_hash: txHash,
+          dataset_id: datasetId,
+          purchase_amount_wei: '0',
+        }),
+      });
+      if (!res.ok) {
+        throw new Error(`publisher returned ${res.status}: ${await res.text()}`);
+      }
+      const body = await res.json();
+      deeplink = body.deeplink;
+      offerUrl = body.offer_url;
+      claimId = body.claim_id;
+      status = 'ready';
+    } catch (e) {
+      errorMsg = (e as Error).message;
+      status = 'error';
+    }
+  }
+
+  // QR via the same external service used elsewhere in the project;
+  // the wallet scans this to receive the PurchaseViewerVC.
+  $: qrSrc = deeplink
+    ? `https://api.qrserver.com/v1/create-qr-code/?size=240x240&data=${encodeURIComponent(deeplink)}`
+    : '';
+
+  onMount(postClaim);
+</script>
+
+<style>
+  .wrap { max-width: 640px; margin: 0 auto; padding: 24px; text-align: center; }
+  .qr { margin: 16px auto; }
+  .meta { font-size: 13px; color: #444; word-break: break-all; }
+  .btn {
+    display: inline-block; padding: 10px 18px; margin: 8px;
+    background: #2563eb; color: white; border-radius: 6px; text-decoration: none;
+  }
+  .btn.secondary { background: #6b7280; }
+  pre { text-align: left; background: #f3f4f6; padding: 12px; border-radius: 4px; }
+  .err { color: #dc2626; }
+</style>
+
+<div class="wrap">
+  <h2>購入完了 — VC を受け取る</h2>
+
+  {#if status === 'claiming'}
+    <p>publisher にクレームを登録中…</p>
+  {:else if status === 'error'}
+    <p class="err">エラー: {errorMsg}</p>
+    <button class="btn" on:click={postClaim}>再試行</button>
+  {:else if status === 'ready'}
+    <p>
+      購入トランザクションを <strong>PurchaseViewerVC</strong> として
+      ウォレットに発行する準備ができました。
+    </p>
+
+    <p>スマホウォレットで以下の QR を読み取るか、ボタンを押してください。</p>
+
+    <img class="qr" src={qrSrc} alt="OID4VCI offer deeplink QR" />
+    <div>
+      <a class="btn" href={deeplink}>ウォレットで開く</a>
+      <a class="btn secondary" href={offerUrl} target="_blank" rel="noreferrer">
+        ブラウザで JSON を見る
+      </a>
+    </div>
+
+    <h3>このクレームの情報</h3>
+    <pre class="meta">{JSON.stringify(
+      {
+        claim_id: claimId,
+        tx_hash: txHash,
+        merchandise: merchandiseAddr,
+        dataset_id: datasetId,
+        buyer_eth_addr: buyerAddr,
+      },
+      null,
+      2
+    )}</pre>
+
+    <p>
+      VC を受領したあとは、ウォレットから OID4VP で提示すれば
+      <code>/platform/data?merchandise=&lt;addr&gt;</code> でデータを
+      取得できます。詳しくは
+      <a
+        href="https://iw3ip.github.io/hands-on/marketplace-vc-bridge/"
+        target="_blank"
+        rel="noreferrer"
+      >ハンズオン</a>を参照。
+    </p>
+  {/if}
+</div>

--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -233,15 +233,40 @@ def platform_ingest(
 
 @app.get("/platform/data")
 def platform_data(
-    dataset_id: str,
+    dataset_id: str | None = None,
+    merchandise: str | None = None,
     authorization: str | None = Header(default=None),
 ) -> dict:
-    """Read ingested rows for a dataset, gated by ViewerToken (Stage 3)."""
+    """Read ingested rows for a dataset, gated by ViewerToken.
+
+    Two ways to identify the dataset:
+      - dataset_id=<id>            (Stage 3 / generic)
+      - merchandise=<address>      (Stage 5 / v2: resolves the
+                                    dataset_id via the marketplace claim
+                                    indexed during /marketplace/claim)
+    Exactly one of the two is required.
+    """
     if not authorization:
         raise HTTPException(status_code=401, detail="missing_authorization_header")
     scheme, _, token = authorization.partition(" ")
     if scheme.lower() != "bearer" or not token:
         raise HTTPException(status_code=401, detail="invalid_authorization_header")
+
+    if (dataset_id is None) == (merchandise is None):
+        raise HTTPException(
+            status_code=400,
+            detail="provide_exactly_one_of_dataset_id_or_merchandise",
+        )
+
+    if merchandise is not None:
+        resolved = ssi_state.dataset_for_merchandise(merchandise)
+        if resolved is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"unknown_merchandise:{merchandise}",
+            )
+        dataset_id = resolved
+
     vt, reason = ssi_state.use_viewer_token(token, dataset_id=dataset_id)
     if not vt:
         audit_repo.write(

--- a/publisher/app/ssi/state.py
+++ b/publisher/app/ssi/state.py
@@ -128,6 +128,10 @@ class SSIStateStore:
         self._service_tokens: dict[str, ServiceToken] = {}
         self._marketplace_claims: dict[str, MarketplaceClaim] = {}
         self._marketplace_claims_by_tx: dict[str, MarketplaceClaim] = {}
+        # M4: merchandise_address -> dataset_id, populated from claims so
+        # /platform/data?merchandise=<addr> can resolve a dataset without
+        # asking the buyer to type it.
+        self._merchandise_dataset: dict[str, str] = {}
         self._offer_ttl = offer_ttl
         self._response_ttl = response_ttl
         self._policy_token_ttl = policy_token_ttl
@@ -418,7 +422,13 @@ class SSIStateStore:
             )
             self._marketplace_claims[claim.claim_id] = claim
             self._marketplace_claims_by_tx[tx_hash] = claim
+            # M4: opportunistically index merchandise -> dataset_id
+            self._merchandise_dataset[merchandise_address.lower()] = dataset_id
         return claim, True
+
+    def dataset_for_merchandise(self, merchandise_address: str) -> str | None:
+        with self._lock:
+            return self._merchandise_dataset.get(merchandise_address.lower())
 
     def get_marketplace_claim(self, claim_id: str) -> MarketplaceClaim | None:
         with self._lock:

--- a/tests/test_marketplace_data_lookup.py
+++ b/tests/test_marketplace_data_lookup.py
@@ -1,0 +1,180 @@
+"""GET /platform/data?merchandise=<addr> reverse lookup (M4 / v2).
+
+The bridge records merchandise_address -> dataset_id during /marketplace/claim;
+M4 lets the buyer fetch data without typing the dataset_id, using the
+merchandise contract address as the index.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from publisher.app.ssi.did_jwk import did_jwk_from_public_jwk
+from publisher.app.ssi.keys import private_key_to_jwk, public_jwk_from_private_jwk
+from publisher.app.ssi.sdjwt import _b64u, _es256_sign, _json_bytes
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setenv("SSI_ISSUER_KEY_PATH", str(tmp_path / "issuer_key.jwk.json"))
+    monkeypatch.setenv("SSI_PRESENTATION_DEFS_DIR", str(repo_root / "examples" / "ssi_wallet"))
+    monkeypatch.setenv("SSI_ISSUER_BASE_URL", "http://testserver")
+    monkeypatch.setenv("AUDIT_DB_PATH", str(tmp_path / "audit.db"))
+    monkeypatch.setenv("CONSENT_STORE_PATH", str(tmp_path / "consents.json"))
+    monkeypatch.setenv("PLATFORM_API_URL", "http://testserver/platform/ingest")
+    monkeypatch.setenv("MQTT_BROKER_HOST", "localhost")
+    monkeypatch.setenv("MQTT_TOPICS", "")
+    monkeypatch.setenv("SSI_PEX_SIDECAR_URL", "http://127.0.0.1:1")
+
+    import importlib
+    import publisher.app.main as pm
+    importlib.reload(pm)
+
+    with patch("publisher.app.mqtt_subscriber.MQTTSubscriber.start", lambda self: None), \
+         patch("publisher.app.mqtt_subscriber.MQTTSubscriber.stop", lambda self: None):
+        from fastapi.testclient import TestClient
+        with TestClient(pm.app) as tc:
+            yield tc
+
+
+_BASE = {
+    "merchandise_address": "0x0000000000000000000000000000000000000abc",
+    "buyer_eth_addr": "0xdeadbeef00000000000000000000000000000000",
+    "tx_hash": "0xfeedface" + "00" * 28,
+    "dataset_id": "home/env/temperature",
+    "purchase_amount_wei": "1",
+}
+
+
+def _proof(priv, pub, nonce, aud):
+    h = _b64u(_json_bytes({"alg": "ES256", "typ": "openid4vci-proof+jwt", "jwk": pub}))
+    p = _b64u(_json_bytes({"nonce": nonce, "aud": aud, "iat": int(time.time())}))
+    sig = _es256_sign(priv, (h + "." + p).encode("ascii"))
+    return h + "." + p + "." + _b64u(sig)
+
+
+def _viewer_token_after_purchase(tc) -> tuple[str, dict]:
+    claim = tc.post("/marketplace/claim", json=_BASE).json()
+    pre_auth = json.loads(__import__("urllib.parse").parse.unquote(
+        claim["deeplink"].split("=", 1)[1]
+    ))["grants"]["urn:ietf:params:oauth:grant-type:pre-authorized_code"]["pre-authorized_code"]
+    pk = ec.generate_private_key(ec.SECP256R1())
+    priv = private_key_to_jwk(pk)
+    pub = public_jwk_from_private_jwk(priv)
+
+    token = tc.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": pre_auth,
+        },
+    ).json()
+    proof = _proof(priv, pub, token["c_nonce"], "http://testserver")
+    cred = tc.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+        json={
+            "format": "vc+sd-jwt",
+            "vct": "https://iw3ip.example/credentials/PurchaseViewerVC/v1",
+            "proof": {"proof_type": "jwt", "jwt": proof},
+        },
+    ).json()
+
+    req = tc.get(
+        "/verifier/request",
+        params={"dataset_id": _BASE["dataset_id"], "vc_kind": "PurchaseViewerVC"},
+        headers={"accept": "application/json"},
+    ).json()
+    sub = {
+        "id": "sub-purchase-viewer-temperature",
+        "definition_id": "purchase-viewer-temperature",
+        "descriptor_map": [{"id": "purchase_viewer_vc_temperature", "format": "vc+sd-jwt", "path": "$"}],
+    }
+    body = tc.post(
+        "/verifier/response",
+        data={
+            "vp_token": cred["credential"],
+            "presentation_submission": json.dumps(sub),
+            "state": req["state"],
+        },
+    ).json()
+    return body["viewer_token"], claim
+
+
+def test_merchandise_lookup_returns_data(client):
+    tok, claim = _viewer_token_after_purchase(client)
+    r = client.get(
+        "/platform/data",
+        params={"merchandise": _BASE["merchandise_address"]},
+        headers={"Authorization": f"Bearer {tok}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["dataset_id"] == _BASE["dataset_id"]
+    assert body["read_count"] == 1
+
+
+def test_merchandise_lookup_is_case_insensitive(client):
+    tok, _ = _viewer_token_after_purchase(client)
+    upper = _BASE["merchandise_address"].upper().replace("0X", "0x")
+    r = client.get(
+        "/platform/data",
+        params={"merchandise": upper},
+        headers={"Authorization": f"Bearer {tok}"},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_unknown_merchandise_returns_404(client):
+    r = client.get(
+        "/platform/data",
+        params={"merchandise": "0x" + "ff" * 20},
+        headers={"Authorization": "Bearer any"},
+    )
+    assert r.status_code == 404
+    assert "unknown_merchandise" in r.json()["detail"]
+
+
+def test_both_or_neither_dataset_id_and_merchandise_rejected(client):
+    # Both
+    r1 = client.get(
+        "/platform/data",
+        params={"dataset_id": "x", "merchandise": "0xabc"},
+        headers={"Authorization": "Bearer any"},
+    )
+    assert r1.status_code == 400
+    # Neither
+    r2 = client.get(
+        "/platform/data",
+        headers={"Authorization": "Bearer any"},
+    )
+    # FastAPI surfaces "missing query" for both being None? Actually
+    # both Optional now, so it goes to our validation:
+    assert r2.status_code in (400, 422)
+
+
+def test_merchandise_lookup_token_dataset_mismatch_rejected(client):
+    """A ViewerToken bound to dataset A must not unlock data via a
+    merchandise that maps to dataset B."""
+    tok, _ = _viewer_token_after_purchase(client)
+    # Register a different merchandise under a different dataset
+    other = {
+        **_BASE,
+        "merchandise_address": "0x" + "11" * 20,
+        "tx_hash": "0x" + "22" * 32,
+        "dataset_id": "home/env/humidity",
+    }
+    client.post("/marketplace/claim", json=other)
+    r = client.get(
+        "/platform/data",
+        params={"merchandise": other["merchandise_address"]},
+        headers={"Authorization": f"Bearer {tok}"},
+    )
+    assert r.status_code == 403
+    assert "dataset_mismatch" in r.json()["detail"]


### PR DESCRIPTION
Combined M4 (publisher backend reverse-lookup) and M5 (iot-market-ui post-purchase QR) of the Marketplace VC Bridge project.

## M4 — publisher backend
- `GET /platform/data` accepts `merchandise=<addr>` as an alternative to `dataset_id=`
- `state.dataset_for_merchandise()` reverse index populated during `/marketplace/claim`
- Exactly one of `dataset_id` or `merchandise` is required

## M5 — iot-market-ui post-purchase
- New route `/purchased/[txHash]` posts to `/marketplace/claim` and renders QR + deeplink for OID4VCI receipt
- Merchandise detail page redirects there after purchase tx confirms

## Tests
5 new in `tests/test_marketplace_data_lookup.py`. **Suite: 56 passed** (5 new + 51 existing).

## What's left
M6 (hands-on docs) follows in a separate PR on the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)