### PR TITLE
fix(bridge): forward public host so wallet-facing deeplinks resolve

### DIFF
--- a/bridge/src/config.ts
+++ b/bridge/src/config.ts
@@ -6,6 +6,11 @@ export interface BridgeConfig {
   hardhatRpc: string;
   iotMarketAddress: string;
   publisherUrl: string;
+  // The host-LAN URL the wallet uses to reach publisher. We forward it
+  // to /marketplace/claim via X-Forwarded-Host so the deeplink it bakes
+  // into the OID4VCI offer stays reachable from the phone, not the
+  // internal "publisher:8080" Docker hostname.
+  publicPublisherUrl: string;
   datasetDefault: string;
 }
 
@@ -16,10 +21,14 @@ function required(name: string): string {
 }
 
 export function loadConfig(): BridgeConfig {
+  const publisherUrl =
+    process.env.BRIDGE_PUBLISHER_URL ?? "http://publisher:8080";
   return {
     hardhatRpc: process.env.BRIDGE_HARDHAT_RPC ?? "http://hardhat:8545",
     iotMarketAddress: required("BRIDGE_IOT_MARKET_ADDRESS"),
-    publisherUrl: process.env.BRIDGE_PUBLISHER_URL ?? "http://publisher:8080",
+    publisherUrl,
+    publicPublisherUrl:
+      process.env.BRIDGE_PUBLIC_PUBLISHER_URL ?? publisherUrl,
     datasetDefault: process.env.BRIDGE_DATASET_DEFAULT ?? "home/env/temperature",
   };
 }

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -7,7 +7,7 @@ import { PublisherClient } from "./publisher_client.js";
 
 async function main() {
   const cfg = loadConfig();
-  const publisher = new PublisherClient(cfg.publisherUrl);
+  const publisher = new PublisherClient(cfg.publisherUrl, cfg.publicPublisherUrl);
   const stop = await startListener({
     rpcUrl: cfg.hardhatRpc,
     iotMarketAddress: cfg.iotMarketAddress,

--- a/bridge/src/publisher_client.ts
+++ b/bridge/src/publisher_client.ts
@@ -18,13 +18,28 @@ export interface ClaimResponse {
 }
 
 export class PublisherClient {
-  constructor(private readonly baseUrl: string) {}
+  /**
+   * @param baseUrl Internal publisher URL (e.g. http://publisher:8080)
+   * @param publicUrl Externally-reachable publisher URL (e.g.
+   *   http://192.168.68.53:8080). Forwarded via X-Forwarded-Host so the
+   *   OID4VCI offer baked into the response uses an URL reachable from
+   *   the buyer's phone rather than the internal Docker hostname.
+   */
+  constructor(
+    private readonly baseUrl: string,
+    private readonly publicUrl: string = baseUrl,
+  ) {}
 
   async claim(req: ClaimRequest): Promise<ClaimResponse> {
     const url = `${this.baseUrl}/marketplace/claim`;
+    const pub = new URL(this.publicUrl);
     const { statusCode, body } = await request(url, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-host": pub.host,
+        "x-forwarded-proto": pub.protocol.replace(":", ""),
+      },
       body: JSON.stringify(req),
     });
     const text = await body.text();

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -66,6 +66,10 @@ services:
       BRIDGE_HARDHAT_RPC: ${BRIDGE_HARDHAT_RPC:-http://host.docker.internal:8545}
       BRIDGE_IOT_MARKET_ADDRESS: ${BRIDGE_IOT_MARKET_ADDRESS:-}
       BRIDGE_PUBLISHER_URL: http://publisher:8080
+      # Externally-reachable publisher URL the wallet uses (LAN IP).
+      # Required so the OID4VCI offer baked by /marketplace/claim
+      # surfaces a deeplink the phone can actually fetch.
+      BRIDGE_PUBLIC_PUBLISHER_URL: ${BRIDGE_PUBLIC_PUBLISHER_URL:-http://host.docker.internal:8080}
       BRIDGE_DATASET_DEFAULT: ${BRIDGE_DATASET_DEFAULT:-home/env/temperature}
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Discovered during M2-M5 e2e: the OID4VCI offer's credential_issuer was baked as http://publisher:8080 (internal Docker name), making the iPhone wallet crash trying to fetch issuer metadata.

Adds BRIDGE_PUBLIC_PUBLISHER_URL env var; bridge sends X-Forwarded-Host/Proto so url_utils resolves to a LAN-reachable URL.