### PR TITLE
feat(stage6/B): resolve dataset_id from Merchandise.additionalInfo

### DIFF
--- a/bridge/src/listener.ts
+++ b/bridge/src/listener.ts
@@ -13,6 +13,12 @@ const IOT_MARKET_ABI = [
   "function getMerchandises() view returns (address[])",
 ];
 
+// We only need the read function to fetch dataset_id from additionalInfo;
+// the Purchase event is parsed via topic0 + the logs interface below.
+const MERCHANDISE_READ_ABI = [
+  "function getAllAdditionalInfo() view returns (tuple(string key, string value)[])",
+];
+
 const PURCHASE_FRAGMENT =
   "event Purchase(address indexed owner, address indexed buyer, string pubkey)";
 const MERCHANDISE_IFACE = new Interface([PURCHASE_FRAGMENT]);
@@ -41,6 +47,31 @@ export async function startListener(opts: ListenerOptions): Promise<() => void> 
 
   let stopped = false;
   const seenTx = new Set<string>();
+  // merchandise_address (lowercased) -> dataset_id resolved from
+  // its additionalInfo. Cached on first lookup so we don't re-query
+  // chain on every event from the same merchandise.
+  const datasetCache = new Map<string, string>();
+
+  const resolveDatasetId = async (merchandiseAddr: string): Promise<string> => {
+    const key = merchandiseAddr.toLowerCase();
+    const hit = datasetCache.get(key);
+    if (hit) return hit;
+    try {
+      const m = new Contract(merchandiseAddr, MERCHANDISE_READ_ABI, provider);
+      const pairs: Array<{ key: string; value: string }> =
+        await m.getAllAdditionalInfo();
+      for (const p of pairs) {
+        if (p.key === "dataset_id" && p.value) {
+          datasetCache.set(key, p.value);
+          return p.value;
+        }
+      }
+    } catch (e) {
+      log(`bridge: getAllAdditionalInfo(${merchandiseAddr}) failed: ${(e as Error).message}`);
+    }
+    datasetCache.set(key, opts.datasetDefault);
+    return opts.datasetDefault;
+  };
 
   const tick = async () => {
     if (stopped) return;
@@ -62,15 +93,16 @@ export async function startListener(opts: ListenerOptions): Promise<() => void> 
           });
           if (!parsed) continue;
           const buyer = parsed.args.buyer as string;
+          const datasetId = await resolveDatasetId(ev.address);
           log(
-            `bridge: Purchase event from ${ev.address} buyer=${buyer} tx=${ev.transactionHash}`,
+            `bridge: Purchase event from ${ev.address} buyer=${buyer} dataset=${datasetId} tx=${ev.transactionHash}`,
           );
           try {
             const resp = await opts.publisher.claim({
               merchandise_address: ev.address,
               buyer_eth_addr: buyer,
               tx_hash: ev.transactionHash,
-              dataset_id: opts.datasetDefault, // TODO M3+: read from Merchandise additionalInfo
+              dataset_id: datasetId,
               purchase_amount_wei: "0", // TODO: read from tx
             });
             log(`bridge: claim ok jti=${resp.claim_id} deeplink=${resp.deeplink}`);

--- a/iot-market-ui/src/routes/merchandise/[address]/+page.svelte
+++ b/iot-market-ui/src/routes/merchandise/[address]/+page.svelte
@@ -39,7 +39,14 @@
 				// page, which calls publisher /marketplace/claim and shows
 				// the OID4VCI deeplink + QR for the wallet to receive a
 				// PurchaseViewerVC. Hand-off is idempotent on tx_hash.
-				const dataset = data.datasetId ?? 'home/env/temperature';
+				//
+				// Stage 6 / case B: dataset_id is read from on-chain
+				// additionalInfo if present; falls back to default for
+				// backwards-compatible deployments.
+				const datasetEntry = data.additionalInfo?.find(
+					(entry: { key: string; value: string }) => entry.key === 'dataset_id'
+				);
+				const dataset = datasetEntry?.value ?? 'home/env/temperature';
 				const params = new URLSearchParams({
 					merchandise: data.address,
 					dataset,

--- a/iot-market/scripts/deployMerchandiseWithIoTMarket.ts
+++ b/iot-market/scripts/deployMerchandiseWithIoTMarket.ts
@@ -1,12 +1,15 @@
 import { ethers } from "hardhat";
 import "dotenv/config";
 
+// Stage 6 / case B: each Merchandise advertises its dataset_id in
+// additionalInfo so the bridge (and iot-market-ui) can read the dataset
+// straight off chain instead of relying on a hardcoded default.
 const metadatas = [
-  { fileType: "mp4", dataSize: "100MB" },
-  { fileType: "jpg", dataSize: "10MB" },
-  { fileType: "txt", dataSize: "1MB" },
-  { fileType: "mp4", dataSize: "16MB" },
-  { fileType: "png", dataSize: "5MB" },
+  { fileType: "mp4", dataSize: "100MB", datasetId: "home/env/temperature" },
+  { fileType: "jpg", dataSize: "10MB", datasetId: "home/env/temperature" },
+  { fileType: "txt", dataSize: "1MB", datasetId: "home/env/humidity" },
+  { fileType: "mp4", dataSize: "16MB", datasetId: "home/env/temperature" },
+  { fileType: "png", dataSize: "5MB", datasetId: "home/env/flood_risk_high" },
 ];
 
 const main = async () => {
@@ -27,8 +30,8 @@ const main = async () => {
       await createDataHash("test"),
       pubKey,
       [deniedBuyer],
-      ["fileType", "dataSize"],
-      [metadatas[i].fileType, metadatas[i].dataSize],
+      ["fileType", "dataSize", "dataset_id"],
+      [metadatas[i].fileType, metadatas[i].dataSize, metadatas[i].datasetId],
     ]);
 
     await merchandise.waitForDeployment();


### PR DESCRIPTION
Stage 6 prerequisite (case B). Merchandise contracts now carry a `dataset_id` entry in their `additionalInfo`, and both the bridge and iot-market-ui read it at runtime.

- bridge/src/listener.ts: per-merchandise dataset cache, falls back to BRIDGE_DATASET_DEFAULT
- iot-market/scripts/deployMerchandiseWithIoTMarket.ts: 5 merchandises now span 3 datasets (temp / humidity / flood_risk_high)
- iot-market-ui /merchandise/[address] redirect reads `additionalInfo` instead of hardcoding

Suite: 56 passed (no publisher change; B-only). The Stage 6 hands-on uses this in a separate PR on the docs site.