### PR TITLE
feat(marketplace): /marketplace/register + seller_did (Stage 7 / C3)

### DIFF
--- a/publisher/app/chain_client.py
+++ b/publisher/app/chain_client.py
@@ -1,0 +1,74 @@
+"""Minimal Ethereum JSON-RPC client used by /marketplace/register.
+
+We only need one read: Merchandise.getOwner(). Rather than pulling in
+web3.py, we craft the eth_call ourselves — getOwner() returns a
+single 20-byte address, which is straightforward to encode/decode.
+
+Selector keccak256("getOwner()")[:4] = 0x893d20e8
+(verified against the Merchandise contract used by the iot-market
+deploy scripts).
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+GET_OWNER_SELECTOR = "0x893d20e8"
+
+
+@dataclass
+class ChainClientSettings:
+    rpc_url: str | None
+    request_timeout_seconds: float = 5.0
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.rpc_url)
+
+
+class ChainClient:
+    def __init__(self, settings: ChainClientSettings) -> None:
+        self._settings = settings
+
+    def _post_rpc(self, method: str, params: list) -> dict:
+        if not self._settings.rpc_url:
+            raise RuntimeError("chain client disabled (no rpc_url)")
+        body = {"jsonrpc": "2.0", "method": method, "params": params, "id": 1}
+        with httpx.Client(timeout=self._settings.request_timeout_seconds) as c:
+            r = c.post(self._settings.rpc_url, json=body)
+            r.raise_for_status()
+            return r.json()
+
+    def merchandise_owner(self, merchandise_address: str) -> str | None:
+        """Return the Merchandise.getOwner() result as a checksum-less
+        lowercase 0x-prefixed address. Returns None on any error so the
+        caller can fail-closed without a stack trace.
+        """
+        if not self._settings.enabled:
+            return None
+        try:
+            payload = self._post_rpc(
+                "eth_call",
+                [
+                    {
+                        "to": merchandise_address,
+                        "data": GET_OWNER_SELECTOR,
+                    },
+                    "latest",
+                ],
+            )
+        except (httpx.HTTPError, httpx.InvalidURL, RuntimeError) as exc:
+            logger.warning("chain RPC eth_call(getOwner) failed: %s", exc)
+            return None
+
+        result = payload.get("result")
+        if not isinstance(result, str) or len(result) < 66:
+            logger.warning("chain RPC eth_call(getOwner) bad result: %r", payload)
+            return None
+        # 32-byte returndata, address right-padded in last 20 bytes.
+        owner_hex = result[-40:]
+        return ("0x" + owner_hex).lower()

--- a/publisher/app/config.py
+++ b/publisher/app/config.py
@@ -18,6 +18,12 @@ class Settings(BaseSettings):
     audit_db_path: str = "audit/audit.db"
     consent_store_path: str | None = None
 
+    # Stage 7 (case C): when set, /marketplace/register verifies that
+    # Merchandise.getOwner() == seller_eth_addr against this RPC. Leave
+    # unset in tests/dev to skip the check (and in audit log we'll mark
+    # the registration as "owner_verify=skipped").
+    marketplace_hardhat_rpc: str | None = None
+
     @property
     def topic_list(self) -> list[str]:
         return [t.strip() for t in self.mqtt_topics.split(",") if t.strip()]

--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -302,10 +302,18 @@ def platform_data(
             presentation_verified="allow",
         )
     )
+    # Stage 7: surface the registered seller_did when the data is being
+    # read via a merchandise lookup so buyers see who sold it. For
+    # plain dataset_id reads we leave seller_did out (no merchandise
+    # context available).
+    seller_did = (
+        ssi_state.seller_for_merchandise(merchandise) if merchandise else None
+    )
     return {
         "dataset_id": vt.dataset_id,
         "count": len(rows),
         "read_count": vt.read_count,
+        "seller_did": seller_did or ("unknown" if merchandise else None),
         "rows": rows,
     }
 
@@ -422,4 +430,142 @@ def marketplace_claim_status(claim_id: str) -> dict:
         "dataset_id": c.dataset_id,
         "status": "delivered" if c.holder_did else "pending",
         "holder_did": c.holder_did,
+    }
+
+
+# ---- Marketplace seller registration (Stage 7 / C3) ----
+
+from publisher.app.chain_client import ChainClient, ChainClientSettings  # noqa: E402
+
+_chain_client = ChainClient(
+    ChainClientSettings(rpc_url=settings.marketplace_hardhat_rpc)
+)
+
+
+@app.post("/marketplace/register")
+def marketplace_register(
+    body: dict,
+    authorization: str | None = Header(default=None),
+) -> dict:
+    """Seller -> publisher: bind a Merchandise to a SellerVC holder.
+
+    Required body fields: merchandise_address, seller_eth_addr,
+    tx_hash, dataset_id. Authorization is a Bearer SellerToken.
+    The dataset_id must be in the SellerToken's licensed_datasets;
+    when MARKETPLACE_HARDHAT_RPC is configured we additionally verify
+    Merchandise.getOwner() == seller_eth_addr (Stage 7 spec Q2).
+    """
+    if not authorization:
+        raise HTTPException(status_code=401, detail="missing_authorization_header")
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(status_code=401, detail="invalid_authorization_header")
+
+    for f in ("merchandise_address", "seller_eth_addr", "tx_hash", "dataset_id"):
+        if not body.get(f):
+            raise HTTPException(status_code=400, detail=f"missing_field:{f}")
+
+    merchandise_address = str(body["merchandise_address"])
+    seller_eth_addr = str(body["seller_eth_addr"]).lower()
+    tx_hash = str(body["tx_hash"])
+    dataset_id = str(body["dataset_id"])
+
+    seller_token, reason = ssi_state.use_seller_token(token, dataset_id=dataset_id)
+    if not seller_token:
+        audit_repo.write(
+            AuditLogRecord(
+                ts=datetime.now(timezone.utc).isoformat(),
+                action="deny",
+                subject_did=f"eth:{seller_eth_addr}",
+                dataset_id=dataset_id,
+                purpose="register",
+                reason=f"seller_token_{reason}",
+                message_hash="",
+                raw_topic="marketplace/seller_registered",
+                holder_did=None,
+                vc_hash=None,
+                presentation_verified="deny",
+            )
+        )
+        status = 401 if reason in ("unknown", "expired") else 403
+        raise HTTPException(status_code=status, detail=f"seller_token_{reason}")
+
+    # On-chain owner verify (Stage 7 spec Q2). When the RPC is not
+    # configured we skip the check and surface that fact in the audit
+    # reason so it's visible after the fact.
+    owner_verify = "skipped"
+    if _chain_client._settings.enabled:  # noqa: SLF001
+        on_chain_owner = _chain_client.merchandise_owner(merchandise_address)
+        if on_chain_owner is None:
+            owner_verify = "rpc_failed"
+            audit_repo.write(
+                AuditLogRecord(
+                    ts=datetime.now(timezone.utc).isoformat(),
+                    action="deny",
+                    subject_did=seller_token.seller_did or f"eth:{seller_eth_addr}",
+                    dataset_id=dataset_id,
+                    purpose="register",
+                    reason=f"chain_rpc_failed:{merchandise_address}",
+                    message_hash="",
+                    raw_topic="marketplace/seller_registered",
+                    holder_did=seller_token.seller_did,
+                    vc_hash=None,
+                    presentation_verified="deny",
+                )
+            )
+            raise HTTPException(status_code=502, detail="chain_rpc_failed")
+        if on_chain_owner != seller_eth_addr:
+            owner_verify = "mismatch"
+            audit_repo.write(
+                AuditLogRecord(
+                    ts=datetime.now(timezone.utc).isoformat(),
+                    action="deny",
+                    subject_did=seller_token.seller_did or f"eth:{seller_eth_addr}",
+                    dataset_id=dataset_id,
+                    purpose="register",
+                    reason=(
+                        f"owner_mismatch:on_chain={on_chain_owner}:"
+                        f"posted={seller_eth_addr}"
+                    ),
+                    message_hash="",
+                    raw_topic="marketplace/seller_registered",
+                    holder_did=seller_token.seller_did,
+                    vc_hash=None,
+                    presentation_verified="deny",
+                )
+            )
+            raise HTTPException(status_code=403, detail="owner_mismatch")
+        owner_verify = "verified"
+
+    seller_did = seller_token.seller_did or "unknown"
+    ssi_state.bind_merchandise_seller(merchandise_address, seller_did)
+
+    audit_repo.write(
+        AuditLogRecord(
+            ts=datetime.now(timezone.utc).isoformat(),
+            action="allow",
+            subject_did=seller_did,
+            dataset_id=dataset_id,
+            purpose="register",
+            reason=(
+                f"seller_register:jti={seller_token.jti}:"
+                f"merchandise={merchandise_address}:eth={seller_eth_addr}:"
+                f"tx={tx_hash}:owner_verify={owner_verify}"
+            ),
+            message_hash="",
+            raw_topic="marketplace/seller_registered",
+            holder_did=seller_token.seller_did,
+            vc_hash=None,
+            presentation_verified="allow",
+        )
+    )
+
+    return {
+        "registered": True,
+        "merchandise_address": merchandise_address,
+        "seller_did": seller_did,
+        "dataset_id": dataset_id,
+        "tx_hash": tx_hash,
+        "register_count": seller_token.register_count,
+        "owner_verify": owner_verify,
     }

--- a/tests/test_marketplace_register.py
+++ b/tests/test_marketplace_register.py
@@ -1,0 +1,387 @@
+"""POST /marketplace/register + seller_did in /platform/data (Stage 7 / C3).
+
+Builds on the SellerVC + SellerToken machinery from C2 and binds a
+seller_did to a merchandise so buyers can see who sold the data.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from publisher.app.ssi.did_jwk import did_jwk_from_public_jwk
+from publisher.app.ssi.keys import private_key_to_jwk, public_jwk_from_private_jwk
+from publisher.app.ssi.sdjwt import _b64u, _es256_sign, _json_bytes
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setenv("SSI_ISSUER_KEY_PATH", str(tmp_path / "issuer_key.jwk.json"))
+    monkeypatch.setenv("SSI_PRESENTATION_DEFS_DIR", str(repo_root / "examples" / "ssi_wallet"))
+    monkeypatch.setenv("SSI_ISSUER_BASE_URL", "http://testserver")
+    monkeypatch.setenv("AUDIT_DB_PATH", str(tmp_path / "audit.db"))
+    monkeypatch.setenv("CONSENT_STORE_PATH", str(tmp_path / "consents.json"))
+    monkeypatch.setenv("PLATFORM_API_URL", "http://testserver/platform/ingest")
+    monkeypatch.setenv("MQTT_BROKER_HOST", "localhost")
+    monkeypatch.setenv("MQTT_TOPICS", "")
+    monkeypatch.setenv("SSI_PEX_SIDECAR_URL", "http://127.0.0.1:1")
+    # Default: no on-chain owner verification (skip the chain RPC).
+    # Individual tests that need to exercise that path patch
+    # _chain_client.merchandise_owner directly.
+
+    import importlib
+    import publisher.app.main as pm
+    importlib.reload(pm)
+
+    with patch("publisher.app.mqtt_subscriber.MQTTSubscriber.start", lambda self: None), \
+         patch("publisher.app.mqtt_subscriber.MQTTSubscriber.stop", lambda self: None):
+        from fastapi.testclient import TestClient
+        with TestClient(pm.app) as tc:
+            yield tc, pm
+
+
+_MERCHANDISE = "0x1111111111111111111111111111111111111111"
+_SELLER_ETH = "0x2222222222222222222222222222222222222222"
+_TX_HASH = "0x" + "a" * 64
+_DATASET = "home/env/temperature"
+
+
+def _holder():
+    pk = ec.generate_private_key(ec.SECP256R1())
+    jwk = private_key_to_jwk(pk)
+    pub = public_jwk_from_private_jwk(jwk)
+    return jwk, pub, did_jwk_from_public_jwk(pub)
+
+
+def _proof(priv, pub, nonce, aud):
+    h = _b64u(_json_bytes({"alg": "ES256", "typ": "openid4vci-proof+jwt", "jwk": pub}))
+    p = _b64u(_json_bytes({"nonce": nonce, "aud": aud, "iat": int(time.time())}))
+    sig = _es256_sign(priv, (h + "." + p).encode("ascii"))
+    return h + "." + p + "." + _b64u(sig)
+
+
+def _issue_seller_token(tc, *, licensed=_DATASET) -> tuple[str, str]:
+    """Returns (seller_token, seller_did)."""
+    priv, pub, holder_did = _holder()
+    offer = tc.get(
+        "/issuer/offer",
+        params={
+            "type": "SellerVC",
+            "seller_id": "ertl-test",
+            "licensed_datasets": licensed,
+        },
+        headers={"accept": "application/json"},
+    ).json()
+    token = tc.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": offer["pre_authorized_code"],
+        },
+    ).json()
+    proof = _proof(priv, pub, token["c_nonce"], "http://testserver")
+    cred = tc.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+        json={
+            "format": "vc+sd-jwt",
+            "vct": "https://iw3ip.example/credentials/SellerVC/v1",
+            "proof": {"proof_type": "jwt", "jwt": proof},
+        },
+    ).json()
+    req = tc.get(
+        "/verifier/request",
+        params={"vc_kind": "SellerVC"},
+        headers={"accept": "application/json"},
+    ).json()
+    sub = {
+        "id": "sub-seller-vc",
+        "definition_id": "seller-vc",
+        "descriptor_map": [{"id": "seller_vc", "format": "vc+sd-jwt", "path": "$"}],
+    }
+    body = tc.post(
+        "/verifier/response",
+        data={
+            "vp_token": cred["credential"],
+            "presentation_submission": json.dumps(sub),
+            "state": req["state"],
+        },
+    ).json()
+    return body["seller_token"], holder_did
+
+
+_BASE_BODY = {
+    "merchandise_address": _MERCHANDISE,
+    "seller_eth_addr": _SELLER_ETH,
+    "tx_hash": _TX_HASH,
+    "dataset_id": _DATASET,
+}
+
+
+def test_register_succeeds_with_licensed_dataset(client):
+    tc, _ = client
+    token, seller_did = _issue_seller_token(tc)
+    r = tc.post(
+        "/marketplace/register",
+        headers={"Authorization": f"Bearer {token}"},
+        json=_BASE_BODY,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["registered"] is True
+    assert body["seller_did"] == seller_did
+    assert body["owner_verify"] == "skipped"  # rpc not configured in tests
+
+
+def test_register_audit_records_seller_register(client):
+    tc, _ = client
+    token, seller_did = _issue_seller_token(tc)
+    tc.post(
+        "/marketplace/register",
+        headers={"Authorization": f"Bearer {token}"},
+        json=_BASE_BODY,
+    )
+    logs = tc.get("/audit/logs?limit=5").json()
+    matches = [
+        log for log in logs
+        if log["raw_topic"] == "marketplace/seller_registered"
+        and log["reason"].startswith("seller_register:")
+    ]
+    assert len(matches) == 1
+    log = matches[0]
+    assert log["holder_did"] == seller_did
+    assert _TX_HASH in log["reason"]
+    assert _MERCHANDISE in log["reason"]
+    assert "owner_verify=skipped" in log["reason"]
+
+
+def test_register_rejects_unlicensed_dataset(client):
+    tc, _ = client
+    token, _ = _issue_seller_token(tc, licensed="home/env/humidity")
+    r = tc.post(
+        "/marketplace/register",
+        headers={"Authorization": f"Bearer {token}"},
+        json=_BASE_BODY,
+    )
+    assert r.status_code == 403
+    assert "dataset_not_licensed" in r.json()["detail"]
+
+
+def test_register_rejects_unknown_token(client):
+    tc, _ = client
+    r = tc.post(
+        "/marketplace/register",
+        headers={"Authorization": "Bearer bogus"},
+        json=_BASE_BODY,
+    )
+    assert r.status_code == 401
+    assert "seller_token_unknown" in r.json()["detail"]
+
+
+def test_register_rejects_missing_field(client):
+    tc, _ = client
+    token, _ = _issue_seller_token(tc)
+    incomplete = {k: v for k, v in _BASE_BODY.items() if k != "tx_hash"}
+    r = tc.post(
+        "/marketplace/register",
+        headers={"Authorization": f"Bearer {token}"},
+        json=incomplete,
+    )
+    assert r.status_code == 400
+    assert "missing_field:tx_hash" in r.json()["detail"]
+
+
+def test_register_rejects_missing_authorization(client):
+    tc, _ = client
+    r = tc.post("/marketplace/register", json=_BASE_BODY)
+    assert r.status_code == 401
+
+
+def test_owner_verify_when_rpc_configured_and_matches(client, monkeypatch):
+    tc, pm = client
+    # Re-enable the chain client by overriding settings; force the
+    # eth_call to return our seller eth address.
+    pm._chain_client._settings.rpc_url = "http://hardhat:8545"  # noqa: SLF001
+    monkeypatch.setattr(
+        pm._chain_client,
+        "merchandise_owner",
+        lambda addr: _SELLER_ETH,
+    )
+
+    token, _ = _issue_seller_token(tc)
+    r = tc.post(
+        "/marketplace/register",
+        headers={"Authorization": f"Bearer {token}"},
+        json=_BASE_BODY,
+    )
+    assert r.status_code == 200
+    assert r.json()["owner_verify"] == "verified"
+
+
+def test_owner_verify_rejects_mismatch(client, monkeypatch):
+    tc, pm = client
+    pm._chain_client._settings.rpc_url = "http://hardhat:8545"  # noqa: SLF001
+    monkeypatch.setattr(
+        pm._chain_client,
+        "merchandise_owner",
+        lambda addr: "0x" + "ff" * 20,
+    )
+
+    token, _ = _issue_seller_token(tc)
+    r = tc.post(
+        "/marketplace/register",
+        headers={"Authorization": f"Bearer {token}"},
+        json=_BASE_BODY,
+    )
+    assert r.status_code == 403
+    assert "owner_mismatch" in r.json()["detail"]
+
+
+def test_platform_data_includes_seller_did_for_registered_merchandise(client):
+    """After /marketplace/register binds a Merchandise to a seller_did,
+    the buyer's GET /platform/data?merchandise=... shows that seller_did
+    in the response."""
+    tc, _ = client
+
+    # 1) Seller registers
+    seller_token, seller_did = _issue_seller_token(tc)
+    tc.post(
+        "/marketplace/register",
+        headers={"Authorization": f"Bearer {seller_token}"},
+        json=_BASE_BODY,
+    )
+
+    # 2) Bridge claim flow to get a ViewerToken bound to the merchandise
+    claim = tc.post(
+        "/marketplace/claim",
+        json={
+            "merchandise_address": _MERCHANDISE,
+            "buyer_eth_addr": "0x" + "33" * 20,
+            "tx_hash": "0x" + "44" * 32,
+            "dataset_id": _DATASET,
+            "purchase_amount_wei": "0",
+        },
+    ).json()
+    pre_auth = json.loads(
+        __import__("urllib.parse").parse.unquote(
+            claim["deeplink"].split("=", 1)[1]
+        )
+    )["grants"]["urn:ietf:params:oauth:grant-type:pre-authorized_code"]["pre-authorized_code"]
+    priv, pub, _ = _holder()
+    tok = tc.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": pre_auth,
+        },
+    ).json()
+    proof = _proof(priv, pub, tok["c_nonce"], "http://testserver")
+    cred = tc.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {tok['access_token']}"},
+        json={
+            "format": "vc+sd-jwt",
+            "vct": "https://iw3ip.example/credentials/PurchaseViewerVC/v1",
+            "proof": {"proof_type": "jwt", "jwt": proof},
+        },
+    ).json()
+    req = tc.get(
+        "/verifier/request",
+        params={"dataset_id": _DATASET, "vc_kind": "PurchaseViewerVC"},
+        headers={"accept": "application/json"},
+    ).json()
+    sub = {
+        "id": "sub-purchase-viewer-temperature",
+        "definition_id": "purchase-viewer-temperature",
+        "descriptor_map": [{"id": "purchase_viewer_vc_temperature", "format": "vc+sd-jwt", "path": "$"}],
+    }
+    presented = tc.post(
+        "/verifier/response",
+        data={
+            "vp_token": cred["credential"],
+            "presentation_submission": json.dumps(sub),
+            "state": req["state"],
+        },
+    ).json()
+    viewer_token = presented["viewer_token"]
+
+    r = tc.get(
+        "/platform/data",
+        params={"merchandise": _MERCHANDISE},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["seller_did"] == seller_did
+
+
+def test_platform_data_seller_did_unknown_when_not_registered(client):
+    """If a Merchandise is fetched but never went through /marketplace/register,
+    seller_did should report 'unknown' rather than crash."""
+    tc, _ = client
+
+    claim = tc.post(
+        "/marketplace/claim",
+        json={
+            "merchandise_address": "0x" + "55" * 20,
+            "buyer_eth_addr": "0x" + "33" * 20,
+            "tx_hash": "0x" + "66" * 32,
+            "dataset_id": _DATASET,
+            "purchase_amount_wei": "0",
+        },
+    ).json()
+    pre_auth = json.loads(
+        __import__("urllib.parse").parse.unquote(
+            claim["deeplink"].split("=", 1)[1]
+        )
+    )["grants"]["urn:ietf:params:oauth:grant-type:pre-authorized_code"]["pre-authorized_code"]
+    priv, pub, _ = _holder()
+    tok = tc.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": pre_auth,
+        },
+    ).json()
+    proof = _proof(priv, pub, tok["c_nonce"], "http://testserver")
+    cred = tc.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {tok['access_token']}"},
+        json={
+            "format": "vc+sd-jwt",
+            "vct": "https://iw3ip.example/credentials/PurchaseViewerVC/v1",
+            "proof": {"proof_type": "jwt", "jwt": proof},
+        },
+    ).json()
+    req = tc.get(
+        "/verifier/request",
+        params={"dataset_id": _DATASET, "vc_kind": "PurchaseViewerVC"},
+        headers={"accept": "application/json"},
+    ).json()
+    sub = {
+        "id": "sub-purchase-viewer-temperature",
+        "definition_id": "purchase-viewer-temperature",
+        "descriptor_map": [{"id": "purchase_viewer_vc_temperature", "format": "vc+sd-jwt", "path": "$"}],
+    }
+    presented = tc.post(
+        "/verifier/response",
+        data={
+            "vp_token": cred["credential"],
+            "presentation_submission": json.dumps(sub),
+            "state": req["state"],
+        },
+    ).json()
+    viewer_token = presented["viewer_token"]
+
+    r = tc.get(
+        "/platform/data",
+        params={"merchandise": "0x" + "55" * 20},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["seller_did"] == "unknown"


### PR DESCRIPTION
## Summary
**Stage 7 / C3** of SellerVC project. Sellers present a SellerVC, then POST `/marketplace/register` to bind a Merchandise contract address to their did:jwk inside the publisher. `/platform/data?merchandise=` now surfaces `seller_did`.

Builds on [C2 #21](https://github.com/ertlnagoya/Blockchain_IoT_Marketplace/pull/21).

## What lands
- **`POST /marketplace/register`**: Bearer SellerToken; body `{merchandise_address, seller_eth_addr, tx_hash, dataset_id}`; checks dataset_id ∈ licensed_datasets; (optional) on-chain Merchandise.getOwner() check
- **Audit**: `raw_topic=marketplace/seller_registered`, `reason=seller_register:...:owner_verify=...`
- **`GET /platform/data?merchandise=` enhancement**: response gains `seller_did`. `"unknown"` when merchandise not registered, `null` for plain dataset_id reads
- **`chain_client.py`**: tiny eth_call wrapper for Merchandise.getOwner() (no web3.py dep). Enabled by `MARKETPLACE_HARDHAT_RPC` env

## On-chain owner verify (spec Q2)
- env `MARKETPLACE_HARDHAT_RPC` not set → skip, audit shows `owner_verify=skipped`
- set + RPC reachable → call getOwner(), reject mismatch (403 `owner_mismatch`)
- set + RPC unreachable → 502 `chain_rpc_failed` (fail-closed)

Default (unset) means tests run without Hardhat.

## Tests
10 new in `tests/test_marketplace_register.py`. **Suite: 75 passed** (10 new + 65 existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)