### PR TITLE
docs(readme): add Stage 8 roadmap (8a-d)

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,3 +433,28 @@ Covers:
 - `dataset_id`: normalized logical data category (for policy matching)
 - `purpose`: reason of sharing (example: `research`)
 - `PEP`: policy enforcement point (planned in Phase 3)
+
+## Roadmap (Phase 2 follow-on, **Stage 8**)
+
+Phase 2 lands 5 VC kinds, 4 token kinds, and 7 hands-on stages
+([overview](https://iw3ip.github.io/design/vc-architecture-overview/)).
+The trust model still has off-chain assumptions that the next stage
+should harden:
+
+- **Stage 8a — EIP-712 binding** (eth_addr ↔ did:jwk anti-impersonation):
+  replace the bridge-trusted `eth_did_bound` audit row with a
+  buyer-signed EIP-712 assertion. Removes bridge as a trusted party.
+- **Stage 8b — On-chain seller guard**: extend `IoTMarket` (or fork
+  to `IoTMarketV2`) so `registerMerchandise()` requires a SellerToken
+  proof on chain. Closes the bypass where contract calls don't go
+  through the publisher.
+- **Stage 8c — VC revocation**: serve W3C Status List 2021 from
+  `/verifier/status` and consult it during presentation. Lets
+  ConsentVC / SellerVC be retracted before they expire.
+- **Stage 8d — On-chain VC verification**: prove SellerVC / ConsentVC
+  validity on chain via signature relay or ZK, so Solidity contracts
+  can read off the VC layer without trusting an off-chain publisher.
+
+Recommended order: 8a → 8c → 8b → 8d (each unblocks the next).
+Track this work via the `stage8` label / project board; full specs
+land at `iw3ip.github.io/docs/design/stage8-*.md` when work begins.

--- a/README_ja.md
+++ b/README_ja.md
@@ -435,3 +435,28 @@ uv run pytest -q
 - `dataset_id`: 正規化後の論理データ分類（ポリシー照合に使用）
 - `purpose`: 共有目的（例: `research`）
 - `PEP`: ポリシー適用ポイント（Phase 3 で導入予定）
+
+## ロードマップ (Phase 2 の次、**Stage 8**)
+
+Phase 2 で 5 種類の VC、4 種類のトークン、7 段階のハンズオンが揃いました
+([全体像](https://iw3ip.github.io/design/vc-architecture-overview/))。
+ただし信頼モデルには **off-chain 前提**がいくつか残っており、次の段階で
+これらを堅化します:
+
+- **Stage 8a — EIP-712 バインド** (eth_addr ↔ did:jwk のなりすまし対策):
+  bridge を信用するだけの `eth_did_bound` audit 行を、buyer 自身が EIP-712
+  形式で署名する形に置き換える。bridge を信用源から外す。
+- **Stage 8b — on-chain 出品ガード**: `IoTMarket` (または新規
+  `IoTMarketV2`) で `registerMerchandise()` が SellerToken proof を
+  on-chain で要求する形に拡張。publisher を経由しない直接コントラクト
+  呼出のバイパスを塞ぐ。
+- **Stage 8c — VC 失効**: W3C Status List 2021 を `/verifier/status` で
+  公開し、提示時に検証する。ConsentVC / SellerVC を有効期限前に取り消し
+  可能にする。
+- **Stage 8d — on-chain VC 検証**: SellerVC / ConsentVC の有効性を
+  on-chain で証明 (signature relay or ZK)。Solidity コントラクト側で
+  publisher を信用せずに VC 層を参照できるようにする。
+
+推奨順: 8a → 8c → 8b → 8d (各段階が次を解放する)。
+作業は `stage8` ラベル / project board で追跡。本格的な仕様は
+`iw3ip.github.io/docs/design/stage8-*.md` に随時。


### PR DESCRIPTION
Records the four Phase-2 follow-on items in both READMEs so they're visible from the repo entry: 8a (EIP-712 binding), 8b (on-chain seller guard), 8c (VC revocation), 8d (on-chain VC verification). Recommended sequencing 8a → 8c → 8b → 8d.