### PR TITLE
feat(ui): PWA shell + onboarding + purchase history (Stage A)

### DIFF
--- a/iot-market-ui/src/app.html
+++ b/iot-market-ui/src/app.html
@@ -1,10 +1,23 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
 
 <head>
 	<meta charset="utf-8" />
 	<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
+	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+	<meta name="theme-color" content="#2563eb" />
+	<meta name="apple-mobile-web-app-capable" content="yes" />
+	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+	<meta name="apple-mobile-web-app-title" content="IW3IP" />
+	<link rel="apple-touch-icon" href="%sveltekit.assets%/favicon.png" />
+	<script>
+		if ('serviceWorker' in navigator) {
+			window.addEventListener('load', () => {
+				navigator.serviceWorker.register('/sw.js').catch(() => {});
+			});
+		}
+	</script>
 	%sveltekit.head%
 </head>
 

--- a/iot-market-ui/src/routes/+layout.svelte
+++ b/iot-market-ui/src/routes/+layout.svelte
@@ -106,9 +106,21 @@
 	{/if}
 	<a
 		class="block border-y border-gray-700 py-2 pl-4 hover:cursor-pointer hover:text-purple-400"
-		href="/"
+		href="/my-data"
 	>
-		Purchase History
+		購入履歴 / データを見る
+	</a>
+	<a
+		class="block border-y border-gray-700 py-2 pl-4 hover:cursor-pointer hover:text-purple-400"
+		href="/seller"
+	>
+		出品する
+	</a>
+	<a
+		class="block border-y border-gray-700 py-2 pl-4 hover:cursor-pointer hover:text-purple-400"
+		href="/welcome"
+	>
+		はじめての方へ
 	</a>
 </div>
 <slot />

--- a/iot-market-ui/src/routes/my-data/+page.svelte
+++ b/iot-market-ui/src/routes/my-data/+page.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  // Buyer's purchase history + on-tap data viewing.
+  //
+  // We store a lightweight history in localStorage when /purchased/[txHash]
+  // succeeds, so this page can list past purchases without round-trips
+  // to the chain. "View data" performs:
+  //   1. open verifier deeplink for PurchaseViewerVC presentation
+  //   2. user presents in iw3ip-wallet
+  //   3. wallet redirects back to /my-data (universal link)
+  //   4. we poll /platform/data?merchandise= with the most recent
+  //      ViewerToken from publisher logs
+  //
+  // For MVP we surface the merchandise + tx + dataset and let the user
+  // run the publisher curl manually; the full automatic loop lands later.
+
+  import { onMount } from 'svelte';
+
+  type HistoryEntry = {
+    txHash: string;
+    merchandise: string;
+    dataset: string;
+    buyer: string;
+    purchasedAt: string;
+  };
+
+  const PUBLISHER_BASE =
+    import.meta.env.VITE_PUBLISHER_URL ?? 'http://localhost:8080';
+
+  let history: HistoryEntry[] = [];
+  let lastViewedRows: any = null;
+  let lastViewError = '';
+
+  onMount(() => {
+    try {
+      const raw = localStorage.getItem('iw3ip:purchase_history');
+      history = raw ? JSON.parse(raw) : [];
+    } catch {
+      history = [];
+    }
+  });
+
+  async function viewData(entry: HistoryEntry) {
+    lastViewError = '';
+    lastViewedRows = null;
+    try {
+      // Hands-on path: user presents PurchaseViewerVC manually via the
+      // verifier link, then pastes the ViewerToken below. Once we move
+      // to integrated wallet (Stage 9), this becomes one tap.
+      const presentUrl =
+        `${PUBLISHER_BASE}/verifier/request?dataset_id=${encodeURIComponent(entry.dataset)}&vc_kind=PurchaseViewerVC`;
+      window.open(presentUrl, '_blank', 'noopener');
+    } catch (e) {
+      lastViewError = (e as Error).message;
+    }
+  }
+
+  let token = '';
+  let activeMerchandise = '';
+  async function fetchData(merchandise: string) {
+    activeMerchandise = merchandise;
+    lastViewedRows = null;
+    lastViewError = '';
+    if (!token) {
+      lastViewError = '閲覧チケット (ViewerToken) を貼り付けてください';
+      return;
+    }
+    try {
+      const res = await fetch(
+        `${PUBLISHER_BASE}/platform/data?merchandise=${encodeURIComponent(merchandise)}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      const body = await res.json();
+      if (!res.ok) {
+        lastViewError = `${res.status}: ${JSON.stringify(body)}`;
+        return;
+      }
+      lastViewedRows = body;
+    } catch (e) {
+      lastViewError = (e as Error).message;
+    }
+  }
+</script>
+
+<style>
+  .wrap { max-width: 720px; margin: 0 auto; padding: 16px; }
+  h1 { font-size: 22px; }
+  .empty { padding: 40px 16px; text-align: center; color: #6b7280; }
+  .item {
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 14px;
+    margin: 10px 0;
+  }
+  .meta { font-size: 12px; color: #6b7280; word-break: break-all; }
+  .btn {
+    display: inline-block;
+    padding: 10px 14px;
+    background: #2563eb;
+    color: white;
+    border-radius: 6px;
+    text-decoration: none;
+    border: none;
+    cursor: pointer;
+    font-weight: bold;
+    margin: 4px 4px 0 0;
+  }
+  .btn.secondary { background: #6b7280; }
+  pre {
+    background: #f3f4f6;
+    padding: 10px;
+    border-radius: 6px;
+    overflow-x: auto;
+    font-size: 12px;
+  }
+  .err { color: #dc2626; }
+  input.token {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    margin-top: 6px;
+  }
+  .small { font-size: 12px; color: #6b7280; }
+</style>
+
+<div class="wrap">
+  <h1>購入履歴</h1>
+
+  {#if history.length === 0}
+    <div class="empty">
+      まだ購入したデータはありません。
+      <br />
+      <a class="btn" href="/" style="margin-top: 16px;">マーケットへ</a>
+    </div>
+  {:else}
+    {#each history as entry}
+      <div class="item">
+        <div><strong>{entry.dataset}</strong></div>
+        <div class="meta">
+          merchandise: {entry.merchandise}<br />
+          tx: {entry.txHash}<br />
+          purchased: {entry.purchasedAt}
+        </div>
+        <button class="btn" on:click={() => viewData(entry)}>
+          閲覧チケットを取得
+        </button>
+        <button class="btn secondary" on:click={() => (activeMerchandise = entry.merchandise)}>
+          このデータを見る
+        </button>
+      </div>
+    {/each}
+
+    {#if activeMerchandise}
+      <div class="item">
+        <strong>データを取得</strong>
+        <p class="small">
+          チケットアプリで提示が完了すると <code>seller_token_issued</code>
+          相当の token がサーバログに出ます。それを以下に貼って取得:
+        </p>
+        <input class="token" bind:value={token} placeholder="ViewerToken (Bearer)" />
+        <button class="btn" on:click={() => fetchData(activeMerchandise)}>
+          取得実行
+        </button>
+
+        {#if lastViewError}
+          <p class="err">エラー: {lastViewError}</p>
+        {/if}
+        {#if lastViewedRows}
+          <pre>{JSON.stringify(lastViewedRows, null, 2)}</pre>
+        {/if}
+      </div>
+    {/if}
+  {/if}
+
+  <p class="small" style="margin-top: 24px;">
+    閲覧チケットの自動取得・自動表示は将来の Stage 9 で対応予定です。
+    現在は手動でトークンを貼る形になっています。
+  </p>
+</div>

--- a/iot-market-ui/src/routes/purchased/[txHash]/+page.svelte
+++ b/iot-market-ui/src/routes/purchased/[txHash]/+page.svelte
@@ -52,6 +52,27 @@
       offerUrl = body.offer_url;
       claimId = body.claim_id;
       status = 'ready';
+      // Persist purchase history so /my-data can list past purchases
+      // without contract round-trips. Idempotent on tx_hash.
+      try {
+        const raw = localStorage.getItem('iw3ip:purchase_history');
+        const list: any[] = raw ? JSON.parse(raw) : [];
+        if (!list.some((e) => e.txHash === txHash)) {
+          list.unshift({
+            txHash,
+            merchandise: merchandiseAddr,
+            dataset: datasetId,
+            buyer: buyerAddr,
+            purchasedAt: new Date().toISOString(),
+          });
+          localStorage.setItem(
+            'iw3ip:purchase_history',
+            JSON.stringify(list.slice(0, 50)),
+          );
+        }
+      } catch {
+        // ignore localStorage failures
+      }
     } catch (e) {
       errorMsg = (e as Error).message;
       status = 'error';

--- a/iot-market-ui/src/routes/welcome/+page.svelte
+++ b/iot-market-ui/src/routes/welcome/+page.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  // PWA onboarding: guide laypeople through the two prerequisite apps
+  // (MetaMask Mobile for ETH payments, IW3IP Wallet for credentials),
+  // then send them to the marketplace.
+  //
+  // Designed for first-time launch from "Add to Home Screen" — no
+  // jargon (お財布 / 閲覧チケット), big tap targets, two scrollable steps.
+
+  let step = 1;
+</script>
+
+<style>
+  .wrap { max-width: 480px; margin: 0 auto; padding: 24px 16px; }
+  h1 { font-size: 22px; margin-bottom: 8px; }
+  p { color: #374151; line-height: 1.6; }
+  .card {
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 18px;
+    margin: 16px 0;
+  }
+  .step-tag {
+    display: inline-block;
+    background: #2563eb;
+    color: white;
+    border-radius: 999px;
+    padding: 2px 10px;
+    font-size: 12px;
+    font-weight: bold;
+    margin-bottom: 8px;
+  }
+  .btn {
+    display: inline-block;
+    width: 100%;
+    text-align: center;
+    padding: 14px;
+    margin: 6px 0;
+    background: #2563eb;
+    color: white;
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: bold;
+    font-size: 16px;
+    border: none;
+    cursor: pointer;
+  }
+  .btn.secondary { background: #6b7280; }
+  .stepper { display: flex; gap: 4px; margin: 12px 0; }
+  .dot { flex: 1; height: 4px; background: #d1d5db; border-radius: 2px; }
+  .dot.active { background: #2563eb; }
+  .small { font-size: 13px; color: #6b7280; }
+</style>
+
+<div class="wrap">
+  <h1>IW3IP データマーケットへようこそ</h1>
+  <p class="small">
+    あなたの IoT データを安全に売買するアプリです。最初に 2 つの準備が必要です。
+  </p>
+
+  <div class="stepper">
+    <div class="dot" class:active={step >= 1}></div>
+    <div class="dot" class:active={step >= 2}></div>
+    <div class="dot" class:active={step >= 3}></div>
+  </div>
+
+  {#if step === 1}
+    <div class="card">
+      <div class="step-tag">STEP 1 / 3</div>
+      <h2>お財布アプリ (MetaMask)</h2>
+      <p>
+        購入の支払いに使う「お財布アプリ」を入れます。MetaMask は世界で
+        いちばん使われているお財布です。
+      </p>
+      <a class="btn" href="https://metamask.io/" target="_blank" rel="noreferrer">
+        MetaMask を入手する
+      </a>
+      <button class="btn secondary" on:click={() => (step = 2)}>
+        もう入っています →
+      </button>
+    </div>
+
+  {:else if step === 2}
+    <div class="card">
+      <div class="step-tag">STEP 2 / 3</div>
+      <h2>閲覧チケット用アプリ (IW3IP Wallet)</h2>
+      <p>
+        購入したデータを見るための「閲覧チケット」を保管するアプリです。
+        商品を買うとアプリが自動で起動して、チケットを受け取ります。
+      </p>
+      <p class="small">
+        ※ 開発中のため、アプリ配布は別途案内されたリンクから取得してください。
+      </p>
+      <button class="btn secondary" on:click={() => (step = 3)}>
+        もう入っています →
+      </button>
+    </div>
+
+  {:else}
+    <div class="card">
+      <div class="step-tag">STEP 3 / 3</div>
+      <h2>準備完了</h2>
+      <p>
+        マーケットへ移動して商品を見てみましょう。お試しなら無料に近い
+        ものから選べます。
+      </p>
+      <a class="btn" href="/">マーケットへ進む</a>
+      <a class="btn secondary" href="/my-data">購入履歴を見る</a>
+    </div>
+  {/if}
+
+  <p class="small" style="margin-top: 24px;">
+    上のステップ表示は単なる進捗ガイドです。アプリを終了しても情報は失われません。
+  </p>
+</div>

--- a/iot-market-ui/static/manifest.webmanifest
+++ b/iot-market-ui/static/manifest.webmanifest
@@ -1,0 +1,26 @@
+{
+  "name": "IW3IP Data Marketplace",
+  "short_name": "IW3IP",
+  "description": "IoT データを VC で売買するマーケットプレイス",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0f172a",
+  "theme_color": "#2563eb",
+  "icons": [
+    {
+      "src": "/favicon.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/favicon.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    }
+  ],
+  "categories": ["productivity", "utilities"]
+}

--- a/iot-market-ui/static/sw.js
+++ b/iot-market-ui/static/sw.js
@@ -1,0 +1,15 @@
+// Minimal service worker so iOS treats the app as installable.
+// We don't precache — the marketplace pages need fresh contract reads,
+// so a network-first strategy with a no-op SW is enough to satisfy
+// the PWA install heuristics.
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', () => {
+  // pass-through — let the browser handle it
+});


### PR DESCRIPTION
First UI pass for Stage A — turns iot-market-ui into a layperson-friendly PWA.

## What lands
- **PWA shell**: `manifest.webmanifest`, minimal pass-through service worker, iOS PWA meta tags, lang=ja
- **`/welcome`**: 3-step onboarding (MetaMask install / IW3IP Wallet install / ready), no jargon
- **`/my-data`**: purchase history from `localStorage` + paste-ViewerToken viewing flow (auto path comes in Stage 9)
- **`/purchased/[txHash]`**: writes to localStorage on success, idempotent on tx_hash, capped at 50 entries
- **`/+layout.svelte`** mobile menu links to `/my-data`, `/seller`, `/welcome`

Hands-on: [iw3ip.github.io PR](https://github.com/ertlnagoya/iw3ip.github.io)

## NOT in this PR (deferred)
- ViewerToken auto-handling (Stage 9 / case B)
- Framework swap to React (case A scope is keep SvelteKit)
- App Store / Play Store native build (case B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)