### PR TITLE
feat(ssi,marketplace): align Stage 1-7 dataset_ids with Stage 0 event namespace

### DIFF
--- a/examples/ssi_wallet/consent-event-flood-risk-high.json
+++ b/examples/ssi_wallet/consent-event-flood-risk-high.json
@@ -1,0 +1,39 @@
+{
+  "id": "consent-event-flood-risk-high",
+  "name": "Consent VC for home/event/flood_risk_high",
+  "purpose": "Verify the wallet holds a ConsentVC allowing flood-risk event sharing.",
+  "iw3ip_dataset_id": "home/event/flood_risk_high",
+  "iw3ip_vc_kind": "ConsentVC",
+  "input_descriptors": [
+    {
+      "id": "consent_vc_event_flood_risk_high",
+      "name": "ConsentVC (event/flood_risk_high)",
+      "format": {
+        "vc+sd-jwt": {
+          "sd-jwt_alg_values": ["ES256"],
+          "kb-jwt_alg_values": ["ES256"]
+        }
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": ["$.vct"],
+            "filter": {
+              "type": "string",
+              "const": "https://iw3ip.example/credentials/ConsentVC/v1"
+            }
+          },
+          {
+            "path": ["$.dataset_id"],
+            "filter": {
+              "type": "string",
+              "const": "home/event/flood_risk_high"
+            }
+          },
+          { "path": ["$.allowed_purposes"], "filter": { "type": "array" } },
+          { "path": ["$.subject_id"] }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/ssi_wallet/consent-possible-littering.json
+++ b/examples/ssi_wallet/consent-possible-littering.json
@@ -1,0 +1,39 @@
+{
+  "id": "consent-possible-littering",
+  "name": "Consent VC for home/event/possible_littering",
+  "purpose": "Verify the wallet holds a ConsentVC allowing webcam littering event sharing.",
+  "iw3ip_dataset_id": "home/event/possible_littering",
+  "iw3ip_vc_kind": "ConsentVC",
+  "input_descriptors": [
+    {
+      "id": "consent_vc_possible_littering",
+      "name": "ConsentVC (possible_littering)",
+      "format": {
+        "vc+sd-jwt": {
+          "sd-jwt_alg_values": ["ES256"],
+          "kb-jwt_alg_values": ["ES256"]
+        }
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": ["$.vct"],
+            "filter": {
+              "type": "string",
+              "const": "https://iw3ip.example/credentials/ConsentVC/v1"
+            }
+          },
+          {
+            "path": ["$.dataset_id"],
+            "filter": {
+              "type": "string",
+              "const": "home/event/possible_littering"
+            }
+          },
+          { "path": ["$.allowed_purposes"], "filter": { "type": "array" } },
+          { "path": ["$.subject_id"] }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/ssi_wallet/purchase-viewer-possible-littering.json
+++ b/examples/ssi_wallet/purchase-viewer-possible-littering.json
@@ -1,0 +1,42 @@
+{
+  "id": "purchase-viewer-possible-littering",
+  "name": "PurchaseViewer VC for home/event/possible_littering",
+  "purpose": "Verify the wallet holds a PurchaseViewerVC bound to a Merchandise.Purchase tx for possible_littering events.",
+  "iw3ip_dataset_id": "home/event/possible_littering",
+  "iw3ip_vc_kind": "PurchaseViewerVC",
+  "input_descriptors": [
+    {
+      "id": "purchase_viewer_vc_possible_littering",
+      "name": "PurchaseViewerVC (possible_littering)",
+      "format": {
+        "vc+sd-jwt": {
+          "sd-jwt_alg_values": ["ES256"],
+          "kb-jwt_alg_values": ["ES256"]
+        }
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": ["$.vct"],
+            "filter": {
+              "type": "string",
+              "const": "https://iw3ip.example/credentials/PurchaseViewerVC/v1"
+            }
+          },
+          {
+            "path": ["$.dataset_id"],
+            "filter": {
+              "type": "string",
+              "const": "home/event/possible_littering"
+            }
+          },
+          { "path": ["$.allowed_actions"], "filter": { "type": "array" } },
+          { "path": ["$.merchandise_address"], "filter": { "type": "string" } },
+          { "path": ["$.buyer_eth_addr"], "filter": { "type": "string" } },
+          { "path": ["$.tx_hash"], "filter": { "type": "string" } },
+          { "path": ["$.subject_id"] }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/ssi_wallet/service-possible-littering.json
+++ b/examples/ssi_wallet/service-possible-littering.json
@@ -1,0 +1,39 @@
+{
+  "id": "service-possible-littering",
+  "name": "Service VC for home/event/possible_littering",
+  "purpose": "Verify the M2M service holds a ServiceVC allowing continuous ingest of littering events.",
+  "iw3ip_dataset_id": "home/event/possible_littering",
+  "iw3ip_vc_kind": "ServiceVC",
+  "input_descriptors": [
+    {
+      "id": "service_vc_possible_littering",
+      "name": "ServiceVC (possible_littering)",
+      "format": {
+        "vc+sd-jwt": {
+          "sd-jwt_alg_values": ["ES256"],
+          "kb-jwt_alg_values": ["ES256"]
+        }
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": ["$.vct"],
+            "filter": {
+              "type": "string",
+              "const": "https://iw3ip.example/credentials/ServiceVC/v1"
+            }
+          },
+          {
+            "path": ["$.dataset_id"],
+            "filter": {
+              "type": "string",
+              "const": "home/event/possible_littering"
+            }
+          },
+          { "path": ["$.allowed_actions"], "filter": { "type": "array" } },
+          { "path": ["$.subject_id"] }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/ssi_wallet/viewer-possible-littering.json
+++ b/examples/ssi_wallet/viewer-possible-littering.json
@@ -1,0 +1,39 @@
+{
+  "id": "viewer-possible-littering",
+  "name": "Viewer VC for home/event/possible_littering",
+  "purpose": "Verify the wallet holds a ViewerVC allowing read of webcam littering events.",
+  "iw3ip_dataset_id": "home/event/possible_littering",
+  "iw3ip_vc_kind": "ViewerVC",
+  "input_descriptors": [
+    {
+      "id": "viewer_vc_possible_littering",
+      "name": "ViewerVC (possible_littering)",
+      "format": {
+        "vc+sd-jwt": {
+          "sd-jwt_alg_values": ["ES256"],
+          "kb-jwt_alg_values": ["ES256"]
+        }
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": ["$.vct"],
+            "filter": {
+              "type": "string",
+              "const": "https://iw3ip.example/credentials/ViewerVC/v1"
+            }
+          },
+          {
+            "path": ["$.dataset_id"],
+            "filter": {
+              "type": "string",
+              "const": "home/event/possible_littering"
+            }
+          },
+          { "path": ["$.allowed_actions"], "filter": { "type": "array" } },
+          { "path": ["$.subject_id"] }
+        ]
+      }
+    }
+  ]
+}

--- a/iot-market/scripts/deployMerchandiseWithIoTMarket.ts
+++ b/iot-market/scripts/deployMerchandiseWithIoTMarket.ts
@@ -4,12 +4,19 @@ import "dotenv/config";
 // Stage 6 / case B: each Merchandise advertises its dataset_id in
 // additionalInfo so the bridge (and iot-market-ui) can read the dataset
 // straight off chain instead of relying on a hardcoded default.
+//
+// The 5 datasets here are intentionally split between the Phase 2
+// "raw" namespace (home/env/*) and the Phase 2 Stage 0 "event"
+// namespace (home/event/*) so the wallet hands-on can keep the same
+// narrative as Stage 0 (webcam-event-sharing, environment-disaster):
+// merchandise #2 surfaces a webcam littering event, #4 a flood-risk
+// event. The temperature entries remain for the basic Stage 5/6 path.
 const metadatas = [
   { fileType: "mp4", dataSize: "100MB", datasetId: "home/env/temperature" },
   { fileType: "jpg", dataSize: "10MB", datasetId: "home/env/temperature" },
-  { fileType: "txt", dataSize: "1MB", datasetId: "home/env/humidity" },
+  { fileType: "json", dataSize: "10KB", datasetId: "home/event/possible_littering" },
   { fileType: "mp4", dataSize: "16MB", datasetId: "home/env/temperature" },
-  { fileType: "png", dataSize: "5MB", datasetId: "home/env/flood_risk_high" },
+  { fileType: "json", dataSize: "10KB", datasetId: "home/event/flood_risk_high" },
 ];
 
 const main = async () => {

--- a/publisher/app/ssi/issuer_routes.py
+++ b/publisher/app/ssi/issuer_routes.py
@@ -63,6 +63,14 @@ DEFAULT_ALLOWED_PURPOSES = {
     "home/env/flood_risk_high": ["safety", "emergency_planning"],
     "home/env/possible_littering": ["community_awareness", "planning"],
     "home/energy/power": ["research", "planning"],
+    # Event-namespace datasets used by the Phase 2 Stage 0 hands-on
+    # (webcam-event-sharing, environment-disaster). Adding them here
+    # lets Stage 1+ wallet flows preserve narrative continuity:
+    # the same camera/environment events that Stage 0 introduced are
+    # gated by VC instead of /consents JSON.
+    "home/event/possible_littering": ["community_cleaning", "research", "planning"],
+    "home/event/flood_risk_high": ["disaster_response", "safety", "emergency_planning"],
+    "home/event/person_detected": ["safety", "research"],
 }
 
 

--- a/tests/test_event_namespace_consistency.py
+++ b/tests/test_event_namespace_consistency.py
@@ -1,0 +1,217 @@
+"""Smoke test: home/event/* dataset_ids work across the same flows
+that home/env/* did, so Phase 2 hands-on can use Stage-0-shaped
+camera / environment events end-to-end without breaking the wallet
+authz layer.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from publisher.app.ssi.did_jwk import did_jwk_from_public_jwk
+from publisher.app.ssi.keys import private_key_to_jwk, public_jwk_from_private_jwk
+from publisher.app.ssi.sdjwt import _b64u, _es256_sign, _json_bytes
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setenv("SSI_ISSUER_KEY_PATH", str(tmp_path / "issuer_key.jwk.json"))
+    monkeypatch.setenv("SSI_PRESENTATION_DEFS_DIR", str(repo_root / "examples" / "ssi_wallet"))
+    monkeypatch.setenv("SSI_ISSUER_BASE_URL", "http://testserver")
+    monkeypatch.setenv("AUDIT_DB_PATH", str(tmp_path / "audit.db"))
+    monkeypatch.setenv("CONSENT_STORE_PATH", str(tmp_path / "consents.json"))
+    monkeypatch.setenv("PLATFORM_API_URL", "http://testserver/platform/ingest")
+    monkeypatch.setenv("MQTT_BROKER_HOST", "localhost")
+    monkeypatch.setenv("MQTT_TOPICS", "")
+    monkeypatch.setenv("SSI_PEX_SIDECAR_URL", "http://127.0.0.1:1")
+
+    import importlib
+    import publisher.app.main as pm
+    importlib.reload(pm)
+
+    with patch("publisher.app.mqtt_subscriber.MQTTSubscriber.start", lambda self: None), \
+         patch("publisher.app.mqtt_subscriber.MQTTSubscriber.stop", lambda self: None):
+        from fastapi.testclient import TestClient
+        with TestClient(pm.app) as tc:
+            yield tc
+
+
+def _holder():
+    pk = ec.generate_private_key(ec.SECP256R1())
+    jwk = private_key_to_jwk(pk)
+    pub = public_jwk_from_private_jwk(jwk)
+    return jwk, pub, did_jwk_from_public_jwk(pub)
+
+
+def _proof(priv, pub, nonce, aud):
+    h = _b64u(_json_bytes({"alg": "ES256", "typ": "openid4vci-proof+jwt", "jwk": pub}))
+    p = _b64u(_json_bytes({"nonce": nonce, "aud": aud, "iat": int(time.time())}))
+    sig = _es256_sign(priv, (h + "." + p).encode("ascii"))
+    return h + "." + p + "." + _b64u(sig)
+
+
+def test_consent_vc_for_event_namespace_can_be_issued_and_presented(client):
+    """ConsentVC issuance + presentation + ingest works for
+    home/event/possible_littering — the dataset Phase 2 Stage 0 already
+    uses, so Stage 1+ hands-on can reuse the same data shape."""
+    priv, pub, _ = _holder()
+
+    offer = client.get(
+        "/issuer/offer",
+        params={
+            "type": "ConsentVC",
+            "dataset_id": "home/event/possible_littering",
+            "purpose": "community_cleaning",
+        },
+        headers={"accept": "application/json"},
+    ).json()
+    assert "community_cleaning" in offer["allowed_purposes"]
+
+    token = client.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": offer["pre_authorized_code"],
+        },
+    ).json()
+    proof = _proof(priv, pub, token["c_nonce"], "http://testserver")
+    cred = client.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+        json={
+            "format": "vc+sd-jwt",
+            "vct": "https://iw3ip.example/credentials/ConsentVC/v1",
+            "proof": {"proof_type": "jwt", "jwt": proof},
+        },
+    ).json()
+
+    req = client.get(
+        "/verifier/request",
+        params={"dataset_id": "home/event/possible_littering", "purpose": "community_cleaning"},
+        headers={"accept": "application/json"},
+    ).json()
+    sub = {
+        "id": "sub-consent-possible-littering",
+        "definition_id": "consent-possible-littering",
+        "descriptor_map": [{"id": "consent_vc_possible_littering", "format": "vc+sd-jwt", "path": "$"}],
+    }
+    body = client.post(
+        "/verifier/response",
+        data={
+            "vp_token": cred["credential"],
+            "presentation_submission": json.dumps(sub),
+            "state": req["state"],
+        },
+    ).json()
+    assert body["status"] == "allowed", body
+    assert body["vc_kind"] == "ConsentVC"
+    policy_token = body["policy_token"]
+
+    # And the policy token actually unlocks an ingest payload that looks
+    # like the Stage 0 webcam-event-sharing payload (rich event data,
+    # not just {"value": 21.4}).
+    r = client.post(
+        "/platform/ingest",
+        headers={"Authorization": f"Bearer {policy_token}"},
+        json={
+            "dataset_id": "home/event/possible_littering",
+            "purpose": "community_cleaning",
+            "event_type": "possible_littering",
+            "data": {
+                "camera_id": "webcam-401",
+                "location": "park-north",
+                "object_class": "bottle",
+                "confidence": 0.87,
+            },
+            "ts": "2026-04-28T11:02:00Z",
+            "source": "edge_inference",
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "received"
+
+
+def test_viewer_vc_for_event_namespace(client):
+    """Same dataset_id is gated for read via ViewerVC + ViewerToken."""
+    priv, pub, _ = _holder()
+
+    offer = client.get(
+        "/issuer/offer",
+        params={"type": "ViewerVC", "dataset_id": "home/event/possible_littering", "purpose": "read"},
+        headers={"accept": "application/json"},
+    ).json()
+    token = client.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": offer["pre_authorized_code"],
+        },
+    ).json()
+    proof = _proof(priv, pub, token["c_nonce"], "http://testserver")
+    cred = client.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+        json={
+            "format": "vc+sd-jwt",
+            "vct": "https://iw3ip.example/credentials/ViewerVC/v1",
+            "proof": {"proof_type": "jwt", "jwt": proof},
+        },
+    ).json()
+
+    req = client.get(
+        "/verifier/request",
+        params={"dataset_id": "home/event/possible_littering", "vc_kind": "ViewerVC"},
+        headers={"accept": "application/json"},
+    ).json()
+    sub = {
+        "id": "sub-viewer-possible-littering",
+        "definition_id": "viewer-possible-littering",
+        "descriptor_map": [{"id": "viewer_vc_possible_littering", "format": "vc+sd-jwt", "path": "$"}],
+    }
+    body = client.post(
+        "/verifier/response",
+        data={
+            "vp_token": cred["credential"],
+            "presentation_submission": json.dumps(sub),
+            "state": req["state"],
+        },
+    ).json()
+    assert body["status"] == "allowed", body
+    assert body["vc_kind"] == "ViewerVC"
+    assert "viewer_token" in body
+
+
+def test_default_allowed_purposes_includes_event_datasets(client):
+    """The DEFAULT_ALLOWED_PURPOSES table must answer for the event
+    datasets we just added; otherwise issuer_offer falls back to a
+    single-element list with whatever purpose the caller passed."""
+    # community_cleaning isn't in any home/env/* default, so if the
+    # offer comes back with that allowed list size > 1, we know the
+    # event-namespace entry was honoured.
+    offer = client.get(
+        "/issuer/offer",
+        params={
+            "type": "ConsentVC",
+            "dataset_id": "home/event/possible_littering",
+            "purpose": "community_cleaning",
+        },
+        headers={"accept": "application/json"},
+    ).json()
+    assert "community_cleaning" in offer["allowed_purposes"]
+    assert "research" in offer["allowed_purposes"]
+
+
+def test_existing_env_namespace_unchanged(client):
+    """Regression: the Stage 1-7 home/env/temperature path keeps working."""
+    offer = client.get(
+        "/issuer/offer",
+        params={"type": "ConsentVC", "dataset_id": "home/env/temperature", "purpose": "research"},
+        headers={"accept": "application/json"},
+    ).json()
+    assert "research" in offer["allowed_purposes"]


### PR DESCRIPTION
Stage 0 (webcam-event-sharing / environment-disaster) tells the story with rich camera/sensor events at `home/event/possible_littering` and `home/event/flood_risk_high`. The wallet hands-on (Stages 1+) had been using `home/env/temperature` with simple `{value: 21.4}` payloads, breaking narrative continuity. This brings the event datasets all the way through the publisher + marketplace stack.

## What lands
- Publisher `DEFAULT_ALLOWED_PURPOSES` gains `home/event/possible_littering`, `home/event/flood_risk_high`, `home/event/person_detected`
- 5 new PD examples (consent / viewer / service / purchase-viewer for possible_littering, plus consent for event/flood_risk_high)
- Marketplace deploy script: 5 Merchandises now span `home/env/temperature` × 3 + `home/event/possible_littering` + `home/event/flood_risk_high`
- 4 new tests (`tests/test_event_namespace_consistency.py`) covering issue/present/ingest with Stage-0-shaped payload, viewer flow, allowed-purposes table, and a regression test for the existing env namespace

## No breaking change
Existing `home/env/*` datasets keep working unchanged. Stage 1-7 hands-on can still use them; new event datasets are additive.

## Suite: 79 passed (4 new + 75 existing)

Hands-on doc updates land in the docs-site PR right after this.