### PR TITLE
feat(ssi): DataUserVC + tiered allowed_views (Stage T alpha)

### DIFF
--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -287,6 +287,28 @@ def platform_data(
         status = 401 if reason in ("unknown", "expired") else 403
         raise HTTPException(status_code=status, detail=f"viewer_token_{reason}")
     rows = [r for r in app.state.ingested if r.get("dataset_id") == dataset_id]
+
+    # Stage T (case alpha): project each row according to the
+    # ViewerToken's allowed_views. Tier 1 (event) hides image_cid /
+    # video_cid; Tier 2 (image) reveals image_cid; Tier 3 (video)
+    # reveals both. This is a strict allowlist: unknown view keys
+    # never leak.
+    allowed_views = vt.allowed_views or ["event"]
+
+    def _project(row: dict) -> dict:
+        out: dict = {}
+        for k, v in row.items():
+            if k == "image_cid" and "image" not in allowed_views:
+                continue
+            if k == "video_cid" and "video" not in allowed_views:
+                continue
+            if k == "video_duration_sec" and "video" not in allowed_views:
+                continue
+            out[k] = v
+        return out
+
+    rows = [_project(r) for r in rows]
+
     audit_repo.write(
         AuditLogRecord(
             ts=datetime.now(timezone.utc).isoformat(),
@@ -294,7 +316,10 @@ def platform_data(
             subject_did=vt.holder_did or "unknown",
             dataset_id=vt.dataset_id,
             purpose="read",
-            reason=f"viewer_token_used:{vt.jti}:{vt.read_count}",
+            reason=(
+                f"viewer_token_used:{vt.jti}:{vt.read_count}"
+                f":views={'+'.join(allowed_views) if allowed_views else 'none'}"
+            ),
             message_hash="",
             raw_topic="platform/data",
             holder_did=vt.holder_did,
@@ -314,6 +339,7 @@ def platform_data(
         "count": len(rows),
         "read_count": vt.read_count,
         "seller_did": seller_did or ("unknown" if merchandise else None),
+        "allowed_views": allowed_views,
         "rows": rows,
     }
 
@@ -343,12 +369,30 @@ def marketplace_claim(body: dict, request: _Request) -> dict:
         if not body.get(f):
             raise HTTPException(status_code=400, detail=f"missing_field:{f}")
 
+    # Stage T (case alpha): if the bridge / iot-market-ui includes the
+    # buyer's DataUserVC trust attributes in the claim body, evaluate
+    # the trust score now and bake the resulting allowed_views into the
+    # claim. Without these, allowed_views defaults to ["event"] (Tier 1).
+    allowed_views: list[str] | None = None
+    trust_score: int | None = None
+    access_level: str | None = None
+    data_user_attrs = body.get("data_user_attrs")
+    if isinstance(data_user_attrs, dict) and data_user_attrs:
+        from publisher.app.ssi.trust_score import evaluate_from_claims
+        evaluation = evaluate_from_claims(data_user_attrs)
+        allowed_views = list(evaluation.allowed_views)
+        trust_score = evaluation.trust_score
+        access_level = evaluation.access_level
+
     claim, created = ssi_state.create_marketplace_claim(
         merchandise_address=body["merchandise_address"],
         buyer_eth_addr=body["buyer_eth_addr"],
         tx_hash=body["tx_hash"],
         dataset_id=body["dataset_id"],
         purchase_amount_wei=str(body.get("purchase_amount_wei", "0")),
+        allowed_views=allowed_views,
+        trust_score=trust_score,
+        access_level=access_level,
     )
 
     # Stitch the claim's pre_authorized_code into a credential offer that

--- a/publisher/app/ssi/issuer_routes.py
+++ b/publisher/app/ssi/issuer_routes.py
@@ -30,6 +30,8 @@ PURCHASE_VIEWER_VC_CONFIG_ID = "PurchaseViewerVC"
 PURCHASE_VIEWER_VCT = "https://iw3ip.example/credentials/PurchaseViewerVC/v1"
 SELLER_VC_CONFIG_ID = "SellerVC"
 SELLER_VCT = "https://iw3ip.example/credentials/SellerVC/v1"
+DATA_USER_VC_CONFIG_ID = "DataUserVC"
+DATA_USER_VCT = "https://iw3ip.example/credentials/DataUserVC/v1"
 
 # Backwards-compatible aliases for code/tests that imported the originals.
 CREDENTIAL_CONFIG_ID = CONSENT_VC_CONFIG_ID
@@ -46,6 +48,7 @@ VC_KIND_TO_VCT = {
     "ServiceVC": SERVICE_VCT,
     "PurchaseViewerVC": PURCHASE_VIEWER_VCT,
     "SellerVC": SELLER_VCT,
+    "DataUserVC": DATA_USER_VCT,
 }
 VC_KIND_TO_CONFIG_ID = {
     "ConsentVC": CONSENT_VC_CONFIG_ID,
@@ -53,6 +56,7 @@ VC_KIND_TO_CONFIG_ID = {
     "ServiceVC": SERVICE_VC_CONFIG_ID,
     "PurchaseViewerVC": PURCHASE_VIEWER_VC_CONFIG_ID,
     "SellerVC": SELLER_VC_CONFIG_ID,
+    "DataUserVC": DATA_USER_VC_CONFIG_ID,
 }
 
 DEEPLINK_SCHEME = "openid-credential-offer://"
@@ -148,6 +152,24 @@ def _credential_issuer_metadata(base_url: str, keys: IssuerKeyStore) -> dict:
                 "claims": {
                     "dataset_id": {"display": [{"name": "Dataset ID"}]},
                     "allowed_actions": {"display": [{"name": "Allowed actions"}]},
+                    "subject_id": {"display": [{"name": "Subject"}], "mandatory": False},
+                    "iw3ip_issuer": {"display": [{"name": "Issuer"}]},
+                },
+            },
+            DATA_USER_VC_CONFIG_ID: {
+                **common_alg,
+                "vct": DATA_USER_VCT,
+                "scope": "DataUserVC",
+                "display": [
+                    {"name": "IW3IP Data User Credential", "locale": "en"},
+                    {"name": "IW3IP データ利用者クレデンシャル", "locale": "ja"},
+                ],
+                "claims": {
+                    "entityType": {"display": [{"name": "Entity type"}]},
+                    "purpose": {"display": [{"name": "Purpose"}]},
+                    "legalCompliance": {"display": [{"name": "Legal compliance"}]},
+                    "dataHandlingPolicy": {"display": [{"name": "Data handling policy"}]},
+                    "misuseRecord": {"display": [{"name": "Misuse record"}]},
                     "subject_id": {"display": [{"name": "Subject"}], "mandatory": False},
                     "iw3ip_issuer": {"display": [{"name": "Issuer"}]},
                 },
@@ -250,8 +272,8 @@ def build_router(deps: IssuerDeps) -> APIRouter:
     def issuer_offer(
         request: Request,
         type: str = Query("ConsentVC", alias="type"),
-        # SellerVC doesn't bind to a single dataset, so dataset_id is
-        # optional for it; required for everything else.
+        # SellerVC / DataUserVC don't bind to a single dataset, so
+        # dataset_id is optional for them; required for everything else.
         dataset_id: str | None = Query(default=None),
         purpose: str = Query("read"),
         seller_id: str | None = Query(default=None),
@@ -259,18 +281,25 @@ def build_router(deps: IssuerDeps) -> APIRouter:
             default=None,
             description="Comma-separated dataset_ids the SellerVC licenses",
         ),
+        # Stage T (case alpha): DataUserVC inputs (mirrors
+        # ssi/contracts/DataUserVerifier.sol)
+        entity_type: str | None = Query(default=None),
+        legal_compliance: bool | None = Query(default=None),
+        data_handling_policy: str | None = Query(default=None),
+        misuse_record: bool | None = Query(default=None),
     ):
         if type not in VC_KIND_TO_CONFIG_ID:
             raise HTTPException(
                 status_code=400,
                 detail=f"unknown VC type: {type} (supported: {list(VC_KIND_TO_CONFIG_ID)})",
             )
-        if type != "SellerVC" and not dataset_id:
+        if type not in ("SellerVC", "DataUserVC") and not dataset_id:
             raise HTTPException(
                 status_code=400, detail="dataset_id required for this VC type"
             )
         config_id = VC_KIND_TO_CONFIG_ID[type]
         offer_seller_id: str | None = None
+        offer_data_user_attrs: dict | None = None
 
         if type == "ConsentVC":
             allowed = DEFAULT_ALLOWED_PURPOSES.get(dataset_id or "", [purpose])
@@ -300,6 +329,28 @@ def build_router(deps: IssuerDeps) -> APIRouter:
             page_title = "IW3IP Seller VC を発行"
             # SellerVC isn't dataset-scoped; carry a sentinel for storage.
             dataset_id = "*"
+        elif type == "DataUserVC":
+            for field_name, field_val in (
+                ("entity_type", entity_type),
+                ("legal_compliance", legal_compliance),
+                ("data_handling_policy", data_handling_policy),
+                ("misuse_record", misuse_record),
+            ):
+                if field_val is None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"{field_name} required for DataUserVC",
+                    )
+            offer_data_user_attrs = {
+                "entityType": entity_type,
+                "purpose": purpose,
+                "legalCompliance": bool(legal_compliance),
+                "dataHandlingPolicy": data_handling_policy,
+                "misuseRecord": bool(misuse_record),
+            }
+            allowed = []  # not used for DataUserVC
+            page_title = "IW3IP Data User VC を発行"
+            dataset_id = "*"
         else:  # PurchaseViewerVC
             allowed = ["read"]
             page_title = "IW3IP Purchase Viewer VC を発行"
@@ -311,6 +362,7 @@ def build_router(deps: IssuerDeps) -> APIRouter:
             allowed_purposes=allowed,
             vc_kind=type,
             seller_id=offer_seller_id,
+            data_user_attrs=offer_data_user_attrs,
         )
         public_base = externally_reachable_base_url(request, deps.settings.issuer_base_url)
         co = _credential_offer(public_base, offer.pre_authorized_code, config_id)
@@ -431,6 +483,10 @@ def build_router(deps: IssuerDeps) -> APIRouter:
                     "buyer_eth_addr": claim.buyer_eth_addr,
                     "tx_hash": claim.tx_hash,
                     "purchased_at": int(claim.created_at),
+                    # Stage T (case alpha): bake tier into the VC so the
+                    # buyer can see what they paid for, and so verifier
+                    # presentation surfaces it back to the publisher.
+                    "allowed_views": claim.allowed_views,
                 })
                 deps.state.attach_holder_to_claim(claim.claim_id, holder_did)
                 # Audit the eth_addr <-> did:jwk binding now that we have both.
@@ -457,6 +513,16 @@ def build_router(deps: IssuerDeps) -> APIRouter:
             plain_claims = {
                 "seller_id": offer.seller_id or "unknown",
                 "licensed_datasets": offer.allowed_purposes,
+                "iw3ip_issuer": deps.settings.issuer_id,
+            }
+        elif offer.vc_kind == "DataUserVC":
+            attrs = offer.data_user_attrs or {}
+            plain_claims = {
+                "entityType": attrs.get("entityType", ""),
+                "purpose": attrs.get("purpose", ""),
+                "legalCompliance": bool(attrs.get("legalCompliance", False)),
+                "dataHandlingPolicy": attrs.get("dataHandlingPolicy", ""),
+                "misuseRecord": bool(attrs.get("misuseRecord", False)),
                 "iw3ip_issuer": deps.settings.issuer_id,
             }
         elif offer.vc_kind in ("ViewerVC", "ServiceVC"):

--- a/publisher/app/ssi/state.py
+++ b/publisher/app/ssi/state.py
@@ -26,6 +26,10 @@ class Offer:
     # Stage 7: SellerVC carries seller_id; licensed_datasets reuses
     # allowed_purposes (it's just a string list slot anyway).
     seller_id: str | None = None
+    # Stage T (case alpha): DataUserVC carries the 5 trust attributes that
+    # Li-san's DataUserVerifier.sol scores. Stored verbatim so the credential
+    # issuer can emit them as VC claims unchanged.
+    data_user_attrs: dict | None = None
 
 
 @dataclass
@@ -67,6 +71,12 @@ class ViewerToken:
 
     Re-usable within TTL (viewing is continuous), unlike PolicyToken which
     is single-use. Each successful /platform/data read bumps `read_count`.
+
+    `allowed_views` (Stage T): a list of view labels the holder is licensed
+    to read. Used by /platform/data to project the response. Standard
+    labels are `event` / `image` / `video`; the publisher applies a strict
+    allowlist. Defaults to `["event"]` for back-compat with VCs that
+    don't carry the claim.
     """
     jti: str
     token: str
@@ -75,6 +85,7 @@ class ViewerToken:
     issued_at: float
     expires_at: float
     read_count: int = 0
+    allowed_views: list[str] = field(default_factory=lambda: ["event"])
 
 
 @dataclass
@@ -93,6 +104,13 @@ class MarketplaceClaim:
     purchase_amount_wei: str
     created_at: float
     holder_did: str | None = None  # filled in M3 once wallet receives the VC
+    # Stage T (case alpha): tier baked into the PurchaseViewerVC at
+    # issuance time. Defaults to ["event"] (Tier 1) when no DataUserVC
+    # context is available; trust_score evaluation can promote it to
+    # Tier 2 / 3.
+    allowed_views: list[str] = field(default_factory=lambda: ["event"])
+    trust_score: int | None = None
+    access_level: str | None = None
 
 
 @dataclass
@@ -188,6 +206,7 @@ class SSIStateStore:
         allowed_purposes: list[str],
         vc_kind: str = "ConsentVC",
         seller_id: str | None = None,
+        data_user_attrs: dict | None = None,
     ) -> Offer:
         code = secrets.token_urlsafe(24)
         offer = Offer(
@@ -199,6 +218,7 @@ class SSIStateStore:
             created_at=time.time(),
             vc_kind=vc_kind,
             seller_id=seller_id,
+            data_user_attrs=data_user_attrs,
         )
         with self._lock:
             self._offers[code] = offer
@@ -335,6 +355,7 @@ class SSIStateStore:
         *,
         dataset_id: str,
         holder_did: str | None,
+        allowed_views: list[str] | None = None,
     ) -> ViewerToken:
         now = time.time()
         vt = ViewerToken(
@@ -344,6 +365,7 @@ class SSIStateStore:
             holder_did=holder_did,
             issued_at=now,
             expires_at=now + self._viewer_token_ttl,
+            allowed_views=list(allowed_views) if allowed_views else ["event"],
         )
         with self._lock:
             self._viewer_tokens[vt.token] = vt
@@ -433,6 +455,9 @@ class SSIStateStore:
         tx_hash: str,
         dataset_id: str,
         purchase_amount_wei: str,
+        allowed_views: list[str] | None = None,
+        trust_score: int | None = None,
+        access_level: str | None = None,
     ) -> tuple[MarketplaceClaim, bool]:
         """Return (claim, created). created=False means we returned the
         previously-recorded claim for this tx_hash (idempotent)."""
@@ -449,6 +474,9 @@ class SSIStateStore:
                 dataset_id=dataset_id,
                 purchase_amount_wei=purchase_amount_wei,
                 created_at=time.time(),
+                allowed_views=list(allowed_views) if allowed_views else ["event"],
+                trust_score=trust_score,
+                access_level=access_level,
             )
             self._marketplace_claims[claim.claim_id] = claim
             self._marketplace_claims_by_tx[tx_hash] = claim

--- a/publisher/app/ssi/trust_score.py
+++ b/publisher/app/ssi/trust_score.py
@@ -1,0 +1,104 @@
+"""Pure-function port of Li-san's `DataUserVerifier.sol` from `/ssi/contracts/`.
+
+The Solidity contract scores 5 attributes from a buyer's DataUserVC into
+a trust score (0-100) and maps it to one of three access levels:
+`full` / `access` / `denied`. This module reproduces that logic in Python
+so the publisher can drive the same evaluation off-chain (and stay in
+sync with the on-chain verifier when Stage 8d / ZK gets wired in).
+
+Stage T (case α) maps the access level to `allowed_views`:
+    full   -> ["event", "image", "video"]
+    access -> ["event", "image"]
+    denied -> []
+
+Keep the scoring constants in lock-step with `DataUserVerifier.sol`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TrustEvaluation:
+    trust_score: int
+    access_level: str  # "full" | "access" | "denied"
+    allowed_views: list[str]
+
+
+# Buckets for entityType (case-insensitive)
+_HIGH_TRUST_ENTITIES = {"GOVERNMENTORGANIZATION", "POLICE"}
+_ENTITY_SCORES = {
+    "GOVERNMENTORGANIZATION": 35,
+    "POLICE": 35,
+    "ENTERPRISE": 20,
+    "RESEARCH ORGANIZATION": 15,
+}
+
+# Buckets for purpose (case-insensitive)
+_PURPOSE_SCORES = {
+    "CRIME SEARCH": 25,
+    "TRAFFIC MANAGEMENT": 20,
+    "RESEARCH": 15,
+}
+
+
+def _entity_score(entity_type: str) -> int:
+    return _ENTITY_SCORES.get(entity_type.upper(), 5)
+
+
+def _purpose_score(purpose: str) -> int:
+    return _PURPOSE_SCORES.get(purpose.upper(), 5)
+
+
+def _level_to_views(access_level: str) -> list[str]:
+    if access_level == "full":
+        return ["event", "image", "video"]
+    if access_level == "access":
+        return ["event", "image"]
+    return []
+
+
+def evaluate(
+    *,
+    entity_type: str,
+    purpose: str,
+    legal_compliance: bool,
+    data_handling_policy: str,
+    misuse_record: bool,
+) -> TrustEvaluation:
+    """Mirror of DataUserVerifier.sol: verifyUserAccess()."""
+    score = _entity_score(entity_type) + _purpose_score(purpose)
+    if legal_compliance:
+        score += 15
+    if data_handling_policy.upper() == "ISO27001":
+        score += 15
+    if misuse_record:
+        score -= 10
+    else:
+        score += 10
+
+    if score >= 80 and entity_type.upper() in _HIGH_TRUST_ENTITIES:
+        access = "full"
+    elif score >= 60:
+        access = "access"
+    else:
+        access = "denied"
+
+    return TrustEvaluation(
+        trust_score=score,
+        access_level=access,
+        allowed_views=_level_to_views(access),
+    )
+
+
+def evaluate_from_claims(claims: dict) -> TrustEvaluation:
+    """Convenience: read the 5 attributes straight from a DataUserVC's
+    decoded claims dict (the publisher applies this when a DataUserVC
+    is presented as part of a marketplace claim)."""
+    return evaluate(
+        entity_type=str(claims.get("entityType") or ""),
+        purpose=str(claims.get("purpose") or ""),
+        legal_compliance=bool(claims.get("legalCompliance", False)),
+        data_handling_policy=str(claims.get("dataHandlingPolicy") or ""),
+        misuse_record=bool(claims.get("misuseRecord", False)),
+    )

--- a/publisher/app/ssi/verifier_routes.py
+++ b/publisher/app/ssi/verifier_routes.py
@@ -139,9 +139,10 @@ def _local_pex_fallback(
                     "claims": claims,
                     "holder_did": None,
                 }
-    # SellerVC isn't dataset-scoped; the dataset check happens at
-    # /marketplace/register time against licensed_datasets.
-    if vc_kind != "SellerVC":
+    # SellerVC / DataUserVC aren't dataset-scoped; the dataset check
+    # happens at /marketplace/register time (SellerVC) or never
+    # (DataUserVC, which only feeds trust evaluation).
+    if vc_kind not in ("SellerVC", "DataUserVC"):
         if claims.get("dataset_id") != dataset_id:
             return {"verified": False, "reason": "dataset_mismatch", "claims": claims, "holder_did": None}
     if vc_kind in ("ViewerVC", "PurchaseViewerVC"):
@@ -157,6 +158,17 @@ def _local_pex_fallback(
             return {"verified": False, "reason": "missing_seller_id", "claims": claims, "holder_did": None}
         if not claims.get("licensed_datasets"):
             return {"verified": False, "reason": "missing_licensed_datasets", "claims": claims, "holder_did": None}
+    elif vc_kind == "DataUserVC":
+        # All five trust attributes must be present so trust_score can be
+        # computed deterministically. legalCompliance / misuseRecord are
+        # booleans; entityType / purpose / dataHandlingPolicy are strings.
+        for k in ("entityType", "purpose", "dataHandlingPolicy"):
+            if not claims.get(k):
+                return {"verified": False, "reason": f"missing_{k}", "claims": claims, "holder_did": None}
+        if "legalCompliance" not in claims:
+            return {"verified": False, "reason": "missing_legalCompliance", "claims": claims, "holder_did": None}
+        if "misuseRecord" not in claims:
+            return {"verified": False, "reason": "missing_misuseRecord", "claims": claims, "holder_did": None}
     else:
         allowed = claims.get("allowed_purposes", [])
         if purpose not in allowed:
@@ -199,9 +211,9 @@ def build_router(deps: VerifierDeps) -> APIRouter:
         purpose: str = Query("read"),
         vc_kind: str = Query("ConsentVC"),
     ):
-        if vc_kind not in ("ConsentVC", "ViewerVC", "ServiceVC", "PurchaseViewerVC", "SellerVC"):
+        if vc_kind not in ("ConsentVC", "ViewerVC", "ServiceVC", "PurchaseViewerVC", "SellerVC", "DataUserVC"):
             raise HTTPException(status_code=400, detail=f"unknown vc_kind: {vc_kind}")
-        if vc_kind != "SellerVC" and dataset_id == "*":
+        if vc_kind not in ("SellerVC", "DataUserVC") and dataset_id == "*":
             raise HTTPException(status_code=400, detail="dataset_id required for this vc_kind")
         match = deps.definitions.find_for_dataset(dataset_id, vc_kind=vc_kind)
         if not match:
@@ -241,6 +253,7 @@ def build_router(deps: VerifierDeps) -> APIRouter:
             "ServiceVC": "IW3IP Service VC を提示",
             "PurchaseViewerVC": "IW3IP Purchase Viewer VC を提示",
             "SellerVC": "IW3IP Seller VC を提示",
+            "DataUserVC": "IW3IP Data User VC を提示",
         }.get(vc_kind, "IW3IP Consent VC を提示")
         html = render_qr_page(
             title=title,
@@ -302,6 +315,24 @@ def build_router(deps: VerifierDeps) -> APIRouter:
                         "claims": [
                             {"path": ["seller_id"]},
                             {"path": ["licensed_datasets"]},
+                            {"path": ["subject_id"]},
+                        ],
+                    }
+                ]
+            }
+        elif req.vc_kind == "DataUserVC":
+            dcql = {
+                "credentials": [
+                    {
+                        "id": "data_user_vc",
+                        "format": "dc+sd-jwt",
+                        "meta": {"vct_values": ["https://iw3ip.example/credentials/DataUserVC/v1"]},
+                        "claims": [
+                            {"path": ["entityType"]},
+                            {"path": ["purpose"]},
+                            {"path": ["legalCompliance"]},
+                            {"path": ["dataHandlingPolicy"]},
+                            {"path": ["misuseRecord"]},
                             {"path": ["subject_id"]},
                         ],
                     }
@@ -405,8 +436,11 @@ def build_router(deps: VerifierDeps) -> APIRouter:
         # Phase 2/3 belt-and-braces purpose/action check after PEX
         claims = result.get("claims") or {}
         if verified:
-            # SellerVC isn't dataset-bound; skip the dataset_id check
-            if req.vc_kind != "SellerVC" and claims.get("dataset_id") not in (None, req.dataset_id):
+            # SellerVC / DataUserVC aren't dataset-bound; skip dataset_id check
+            if (
+                req.vc_kind not in ("SellerVC", "DataUserVC")
+                and claims.get("dataset_id") not in (None, req.dataset_id)
+            ):
                 verified = False
                 reason = "dataset_mismatch"
             elif req.vc_kind in ("ViewerVC", "PurchaseViewerVC"):
@@ -426,6 +460,14 @@ def build_router(deps: VerifierDeps) -> APIRouter:
                 elif not claims.get("licensed_datasets"):
                     verified = False
                     reason = "missing_licensed_datasets"
+            elif req.vc_kind == "DataUserVC":
+                # Only check that the 5 attributes are present here.
+                # Trust score is computed at the marketplace claim step.
+                for k in ("entityType", "purpose", "dataHandlingPolicy"):
+                    if not claims.get(k):
+                        verified = False
+                        reason = f"missing_{k}"
+                        break
             else:
                 allowed = claims.get("allowed_purposes")
                 if allowed is not None and req.purpose not in allowed:
@@ -447,14 +489,27 @@ def build_router(deps: VerifierDeps) -> APIRouter:
         )
         if verified:
             if req.vc_kind in ("ViewerVC", "PurchaseViewerVC"):
+                # Stage T (case alpha): pull allowed_views from the VC's
+                # claims when present (PurchaseViewerVC) and propagate it
+                # to the ViewerToken; this gates the response projection
+                # at /platform/data. Defaults to ["event"] for VCs
+                # without the claim (back-compat).
+                allowed_views_claim = claims.get("allowed_views")
+                token_views = (
+                    list(allowed_views_claim)
+                    if isinstance(allowed_views_claim, list) and allowed_views_claim
+                    else ["event"]
+                )
                 vt = deps.state.create_viewer_token(
                     dataset_id=req.dataset_id,
                     holder_did=holder_did,
+                    allowed_views=token_views,
                 )
                 logger.info(
-                    "viewer_token_issued vc_kind=%s jti=%s token=%s dataset=%s ttl=%ss",
+                    "viewer_token_issued vc_kind=%s jti=%s token=%s dataset=%s ttl=%ss views=%s",
                     req.vc_kind, vt.jti, vt.token, vt.dataset_id,
                     int(vt.expires_at - vt.issued_at),
+                    "+".join(vt.allowed_views),
                 )
                 resp: dict = {
                     "status": "allowed",
@@ -463,6 +518,7 @@ def build_router(deps: VerifierDeps) -> APIRouter:
                     "viewer_token": vt.token,
                     "viewer_token_jti": vt.jti,
                     "expires_in": int(vt.expires_at - vt.issued_at),
+                    "allowed_views": vt.allowed_views,
                 }
                 # Surface marketplace context in the response so the
                 # iot-market-ui flow (M5) can correlate without re-decoding
@@ -493,6 +549,29 @@ def build_router(deps: VerifierDeps) -> APIRouter:
                     "seller_id": claims.get("seller_id"),
                     "licensed_datasets": seller_st.licensed_datasets,
                     "expires_in": int(seller_st.expires_at - seller_st.issued_at),
+                }
+            if req.vc_kind == "DataUserVC":
+                # No token minted: DataUserVC presentation is informational
+                # (the publisher just confirms it can compute the trust score
+                # and reports the result). Subsequent ViewerToken / Purchase
+                # flows pick up the trust evaluation via /marketplace/claim.
+                from publisher.app.ssi.trust_score import evaluate_from_claims
+                trust = evaluate_from_claims(claims)
+                logger.info(
+                    "data_user_vc_verified holder=%s entity=%s purpose=%s trust=%s level=%s",
+                    holder_did,
+                    claims.get("entityType"),
+                    claims.get("purpose"),
+                    trust.trust_score,
+                    trust.access_level,
+                )
+                return {
+                    "status": "allowed",
+                    "vc_kind": "DataUserVC",
+                    "trust_score": trust.trust_score,
+                    "access_level": trust.access_level,
+                    "allowed_views": trust.allowed_views,
+                    "holder_did": holder_did,
                 }
             if req.vc_kind == "ServiceVC":
                 st = deps.state.create_service_token(

--- a/tests/test_data_user_vc_tiered.py
+++ b/tests/test_data_user_vc_tiered.py
@@ -1,0 +1,416 @@
+"""DataUserVC + tiered allowed_views projection (Stage T / case alpha).
+
+Verifies:
+  - trust_score module mirrors DataUserVerifier.sol scoring
+  - DataUserVC issuance + presentation works for the 5 attributes
+  - /platform/data projects rows according to ViewerToken.allowed_views
+  - /marketplace/claim accepts data_user_attrs and bakes allowed_views
+    into the resulting PurchaseViewerVC
+  - existing ViewerVC flow without allowed_views falls back to Tier 1
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from publisher.app.ssi.did_jwk import did_jwk_from_public_jwk
+from publisher.app.ssi.keys import private_key_to_jwk, public_jwk_from_private_jwk
+from publisher.app.ssi.sdjwt import _b64u, _es256_sign, _json_bytes
+from publisher.app.ssi.trust_score import (
+    evaluate,
+    evaluate_from_claims,
+)
+
+
+# ---- trust_score pure-function tests ----
+
+def test_trust_full_for_government_research_iso27001():
+    """Mirror of Solidity scoring: gov(35)+research(15)+legal(15)+iso(15)+clean(10) = 90 -> full"""
+    e = evaluate(
+        entity_type="GovernmentOrganization",
+        purpose="research",
+        legal_compliance=True,
+        data_handling_policy="ISO27001",
+        misuse_record=False,
+    )
+    assert e.trust_score == 90
+    assert e.access_level == "full"
+    assert e.allowed_views == ["event", "image", "video"]
+
+
+def test_trust_access_for_enterprise():
+    """enterprise(20)+research(15)+legal(15)+iso(15)+clean(10) = 75; not gov so capped at 'access'"""
+    e = evaluate(
+        entity_type="Enterprise",
+        purpose="research",
+        legal_compliance=True,
+        data_handling_policy="ISO27001",
+        misuse_record=False,
+    )
+    assert e.trust_score == 75
+    assert e.access_level == "access"
+    assert e.allowed_views == ["event", "image"]
+
+
+def test_trust_denied_for_low_score():
+    """unknown(5)+unknown(5)+nolegal+nopolicy+misuse = 5+5-10 = 0 -> denied"""
+    e = evaluate(
+        entity_type="Random",
+        purpose="other",
+        legal_compliance=False,
+        data_handling_policy="",
+        misuse_record=True,
+    )
+    assert e.trust_score == 0
+    assert e.access_level == "denied"
+    assert e.allowed_views == []
+
+
+def test_trust_full_requires_high_score_AND_gov_or_police():
+    """gov score 90 -> full; same score with enterprise -> only access"""
+    gov = evaluate(
+        entity_type="Police",
+        purpose="crime search",
+        legal_compliance=True,
+        data_handling_policy="ISO27001",
+        misuse_record=False,
+    )
+    assert gov.access_level == "full"
+
+    ent_high = evaluate(
+        entity_type="Enterprise",
+        purpose="crime search",
+        legal_compliance=True,
+        data_handling_policy="ISO27001",
+        misuse_record=False,
+    )
+    assert ent_high.trust_score >= 80
+    # Not gov/police, so still "access"
+    assert ent_high.access_level == "access"
+
+
+def test_evaluate_from_claims():
+    e = evaluate_from_claims({
+        "entityType": "GovernmentOrganization",
+        "purpose": "research",
+        "legalCompliance": True,
+        "dataHandlingPolicy": "ISO27001",
+        "misuseRecord": False,
+    })
+    assert e.access_level == "full"
+
+
+# ---- API integration tests ----
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setenv("SSI_ISSUER_KEY_PATH", str(tmp_path / "issuer_key.jwk.json"))
+    monkeypatch.setenv("SSI_PRESENTATION_DEFS_DIR", str(repo_root / "examples" / "ssi_wallet"))
+    monkeypatch.setenv("SSI_ISSUER_BASE_URL", "http://testserver")
+    monkeypatch.setenv("AUDIT_DB_PATH", str(tmp_path / "audit.db"))
+    monkeypatch.setenv("CONSENT_STORE_PATH", str(tmp_path / "consents.json"))
+    monkeypatch.setenv("PLATFORM_API_URL", "http://testserver/platform/ingest")
+    monkeypatch.setenv("MQTT_BROKER_HOST", "localhost")
+    monkeypatch.setenv("MQTT_TOPICS", "")
+    monkeypatch.setenv("SSI_PEX_SIDECAR_URL", "http://127.0.0.1:1")
+
+    import importlib
+    import publisher.app.main as pm
+    importlib.reload(pm)
+
+    with patch("publisher.app.mqtt_subscriber.MQTTSubscriber.start", lambda self: None), \
+         patch("publisher.app.mqtt_subscriber.MQTTSubscriber.stop", lambda self: None):
+        from fastapi.testclient import TestClient
+        with TestClient(pm.app) as tc:
+            yield tc, pm
+
+
+def test_issuer_metadata_lists_data_user_vc(client):
+    tc, _ = client
+    cfgs = tc.get("/.well-known/openid-credential-issuer").json()["credential_configurations_supported"]
+    assert "DataUserVC" in cfgs
+    assert cfgs["DataUserVC"]["vct"].endswith("/DataUserVC/v1")
+
+
+def test_data_user_vc_offer_requires_attributes(client):
+    tc, _ = client
+    r = tc.get(
+        "/issuer/offer",
+        params={"type": "DataUserVC"},
+        headers={"accept": "application/json"},
+    )
+    assert r.status_code == 400
+
+
+def test_marketplace_claim_with_data_user_attrs_promotes_views(client):
+    tc, _ = client
+    body = {
+        "merchandise_address": "0x" + "ab" * 20,
+        "buyer_eth_addr": "0x" + "cd" * 20,
+        "tx_hash": "0x" + "ef" * 32,
+        "dataset_id": "home/event/possible_littering",
+        "data_user_attrs": {
+            "entityType": "GovernmentOrganization",
+            "purpose": "research",
+            "legalCompliance": True,
+            "dataHandlingPolicy": "ISO27001",
+            "misuseRecord": False,
+        },
+    }
+    r = tc.post("/marketplace/claim", json=body)
+    assert r.status_code == 200, r.text
+    # The response shape doesn't (yet) surface allowed_views, so verify
+    # via internal state via the GET /marketplace/claim/{id}
+    claim_id = r.json()["claim_id"]
+    # The claim record itself isn't exposed verbatim, but its
+    # pre_authorized_code now points to an Offer; we simulate the rest of
+    # the flow in test_purchase_viewer_vc_inherits_allowed_views.
+    assert claim_id
+
+
+def test_marketplace_claim_without_data_user_attrs_defaults_event_only(client):
+    tc, pm = client
+    body = {
+        "merchandise_address": "0x" + "11" * 20,
+        "buyer_eth_addr": "0x" + "22" * 20,
+        "tx_hash": "0x" + "33" * 32,
+        "dataset_id": "home/env/temperature",
+    }
+    tc.post("/marketplace/claim", json=body)
+    # Inspect the stored claim
+    claim_id = tc.post("/marketplace/claim", json=body).json()["claim_id"]
+    claim = pm.ssi_state.get_marketplace_claim(claim_id)
+    assert claim.allowed_views == ["event"]
+    assert claim.trust_score is None
+
+
+def _holder():
+    pk = ec.generate_private_key(ec.SECP256R1())
+    jwk = private_key_to_jwk(pk)
+    pub = public_jwk_from_private_jwk(jwk)
+    return jwk, pub, did_jwk_from_public_jwk(pub)
+
+
+def _proof(priv, pub, nonce, aud):
+    h = _b64u(_json_bytes({"alg": "ES256", "typ": "openid4vci-proof+jwt", "jwk": pub}))
+    p = _b64u(_json_bytes({"nonce": nonce, "aud": aud, "iat": int(time.time())}))
+    sig = _es256_sign(priv, (h + "." + p).encode("ascii"))
+    return h + "." + p + "." + _b64u(sig)
+
+
+def _purchase_viewer_token(tc, *, allowed_views_in_claim: list[str]):
+    """End-to-end: claim with given views → receive PurchaseViewerVC →
+    present → returned ViewerToken should carry allowed_views."""
+    # Use trust_score-derived allowed_views via data_user_attrs.
+    # Map views back to representative attributes.
+    if allowed_views_in_claim == ["event", "image", "video"]:
+        attrs = {
+            "entityType": "GovernmentOrganization",
+            "purpose": "research",
+            "legalCompliance": True,
+            "dataHandlingPolicy": "ISO27001",
+            "misuseRecord": False,
+        }
+    elif allowed_views_in_claim == ["event", "image"]:
+        attrs = {
+            "entityType": "Enterprise",
+            "purpose": "research",
+            "legalCompliance": True,
+            "dataHandlingPolicy": "ISO27001",
+            "misuseRecord": False,
+        }
+    else:
+        attrs = None
+
+    body: dict = {
+        "merchandise_address": "0x" + "44" * 20,
+        "buyer_eth_addr": "0x" + "55" * 20,
+        "tx_hash": "0x" + "66" * 32,
+        "dataset_id": "home/env/temperature",
+    }
+    if attrs:
+        body["data_user_attrs"] = attrs
+
+    claim_resp = tc.post("/marketplace/claim", json=body).json()
+    deeplink = claim_resp["deeplink"]
+    pre_auth = json.loads(__import__("urllib.parse").parse.unquote(
+        deeplink.split("=", 1)[1]
+    ))["grants"]["urn:ietf:params:oauth:grant-type:pre-authorized_code"]["pre-authorized_code"]
+
+    priv, pub, _ = _holder()
+    token = tc.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": pre_auth,
+        },
+    ).json()
+    proof = _proof(priv, pub, token["c_nonce"], "http://testserver")
+    cred = tc.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+        json={
+            "format": "vc+sd-jwt",
+            "vct": "https://iw3ip.example/credentials/PurchaseViewerVC/v1",
+            "proof": {"proof_type": "jwt", "jwt": proof},
+        },
+    ).json()
+
+    req = tc.get(
+        "/verifier/request",
+        params={"dataset_id": "home/env/temperature", "vc_kind": "PurchaseViewerVC"},
+        headers={"accept": "application/json"},
+    ).json()
+    sub = {
+        "id": "sub-purchase-viewer-temperature",
+        "definition_id": "purchase-viewer-temperature",
+        "descriptor_map": [{"id": "purchase_viewer_vc_temperature", "format": "vc+sd-jwt", "path": "$"}],
+    }
+    presented = tc.post(
+        "/verifier/response",
+        data={
+            "vp_token": cred["credential"],
+            "presentation_submission": json.dumps(sub),
+            "state": req["state"],
+        },
+    ).json()
+    return presented
+
+
+def test_purchase_viewer_vc_inherits_allowed_views(client):
+    """Tier 3 attrs in claim → Tier 3 allowed_views in PurchaseViewerVC + ViewerToken."""
+    tc, _ = client
+    presented = _purchase_viewer_token(tc, allowed_views_in_claim=["event", "image", "video"])
+    assert presented["status"] == "allowed", presented
+    assert presented["allowed_views"] == ["event", "image", "video"]
+
+
+def test_platform_data_projects_image_video_for_tier_3(client):
+    tc, _ = client
+    # Seed a row with image_cid + video_cid so projection has something to filter
+    pm = __import__("publisher.app.main", fromlist=["app"])
+    pm.app.state.ingested.append({
+        "dataset_id": "home/env/temperature",
+        "event_type": "tick",
+        "data": {"value": 1},
+        "image_cid": "QmTier2Image",
+        "video_cid": "QmTier3Video",
+        "video_duration_sec": 5,
+    })
+
+    presented = _purchase_viewer_token(tc, allowed_views_in_claim=["event", "image", "video"])
+    token = presented["viewer_token"]
+    r = tc.get(
+        "/platform/data",
+        params={"dataset_id": "home/env/temperature"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["allowed_views"] == ["event", "image", "video"]
+    row = body["rows"][0]
+    assert row["image_cid"] == "QmTier2Image"
+    assert row["video_cid"] == "QmTier3Video"
+    assert row["video_duration_sec"] == 5
+
+
+def test_platform_data_hides_video_for_tier_2(client):
+    tc, _ = client
+    pm = __import__("publisher.app.main", fromlist=["app"])
+    pm.app.state.ingested.append({
+        "dataset_id": "home/env/temperature",
+        "event_type": "tick",
+        "data": {"value": 2},
+        "image_cid": "QmImage",
+        "video_cid": "QmVideo",
+    })
+
+    presented = _purchase_viewer_token(tc, allowed_views_in_claim=["event", "image"])
+    token = presented["viewer_token"]
+    r = tc.get(
+        "/platform/data",
+        params={"dataset_id": "home/env/temperature"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    body = r.json()
+    assert body["allowed_views"] == ["event", "image"]
+    row = body["rows"][0]
+    assert row["image_cid"] == "QmImage"
+    assert "video_cid" not in row
+
+
+def test_platform_data_hides_image_and_video_for_tier_1(client):
+    """A vanilla ViewerVC (no allowed_views claim) should default to
+    Tier 1 = event only. Image/video CIDs in the row must be filtered."""
+    tc, _ = client
+    pm = __import__("publisher.app.main", fromlist=["app"])
+    pm.app.state.ingested.append({
+        "dataset_id": "home/env/temperature",
+        "event_type": "tick",
+        "data": {"value": 3},
+        "image_cid": "QmShouldBeHidden",
+        "video_cid": "QmShouldBeHiddenToo",
+    })
+
+    # Issue + present a regular ViewerVC (no allowed_views claim)
+    priv, pub, _ = _holder()
+    offer = tc.get(
+        "/issuer/offer",
+        params={"type": "ViewerVC", "dataset_id": "home/env/temperature", "purpose": "read"},
+        headers={"accept": "application/json"},
+    ).json()
+    token = tc.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": offer["pre_authorized_code"],
+        },
+    ).json()
+    proof = _proof(priv, pub, token["c_nonce"], "http://testserver")
+    cred = tc.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+        json={
+            "format": "vc+sd-jwt",
+            "vct": "https://iw3ip.example/credentials/ViewerVC/v1",
+            "proof": {"proof_type": "jwt", "jwt": proof},
+        },
+    ).json()
+    req = tc.get(
+        "/verifier/request",
+        params={"dataset_id": "home/env/temperature", "vc_kind": "ViewerVC"},
+        headers={"accept": "application/json"},
+    ).json()
+    sub = {
+        "id": "sub-viewer-temperature",
+        "definition_id": "viewer-temperature",
+        "descriptor_map": [{"id": "viewer_vc_temperature", "format": "vc+sd-jwt", "path": "$"}],
+    }
+    presented = tc.post(
+        "/verifier/response",
+        data={
+            "vp_token": cred["credential"],
+            "presentation_submission": json.dumps(sub),
+            "state": req["state"],
+        },
+    ).json()
+    viewer_token = presented["viewer_token"]
+    assert presented["allowed_views"] == ["event"]
+
+    r = tc.get(
+        "/platform/data",
+        params={"dataset_id": "home/env/temperature"},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    body = r.json()
+    assert body["allowed_views"] == ["event"]
+    row = body["rows"][0]
+    assert "image_cid" not in row
+    assert "video_cid" not in row
+    assert row["data"]["value"] == 3


### PR DESCRIPTION
## Summary
- Adds a 6th VC kind, **DataUserVC**, carrying the recipient's trust attributes (entityType / purpose / legalCompliance / dataHandlingPolicy / misuseRecord).
- Ports the trustScore weights from Li-lab's \`DataUserVerifier.sol\` to a pure-Python module (\`publisher/app/ssi/trust_score.py\`) — no on-chain call (rationale in the spec doc).
- \`/marketplace/claim\` consumes \`data_user_attrs\`, evaluates \`access_level\` (\`full\` / \`access\` / \`denied\`), and freezes the resulting \`allowed_views\` into the issued PurchaseViewerVC and the ViewerToken minted from it.
- \`/platform/data\` now projects \`image_cid\` / \`video_cid\` / \`video_duration_sec\` only when \`allowed_views\` permits.

## Why
Li-lab already has a research prototype (\`/ssi\`, W3C VC v1, did:key, on-chain verifier). The Phase 2 stack (\`/issuer\` + \`/verifier\`, SD-JWT VC, did:jwk) overlaps technically but uses different formats. This PR is **Option α — minimum integration**: we re-use the *logic* (weights & thresholds) but keep the format/transport on the Phase 2 side. \`ssi-ui\` is treated as deprecated.

## Tests
\`\`\`
uv run pytest -q
# 88 passed (75 existing + 13 new), no regressions
\`\`\`

\`tests/test_data_user_vc_tiered.py\` covers:
- \`evaluate()\` pure-function parity with the Solidity contract (4 cases incl. the score≥80 + non-gov/police negative case)
- \`evaluate_from_claims()\` wrapper
- issuer metadata exposes DataUserVC
- \`/issuer/offer?vc_kind=DataUserVC\` requires the 5 attributes
- \`/marketplace/claim\` trust promotion + default to event-only
- PurchaseViewerVC inherits \`allowed_views\` from the claim
- \`/platform/data\` projection at Tier 1 / 2 / 3

## Test plan
- [ ] iPhone real-device: issue 3 DataUserVC profiles, claim, present PurchaseViewerVC, fetch \`/platform/data\` and confirm image/video keys appear or disappear by tier
- [ ] Audit log shows DataUserVC verify → claim → token mint → fetch all linked by holder_did

🤖 Generated with [Claude Code](https://claude.com/claude-code)