### PR TITLE
feat(ssi): Stage T UX - tier-aware cards + media hoist + PD

### DIFF
--- a/examples/ssi_wallet/purchase-viewer-possible-littering.json
+++ b/examples/ssi_wallet/purchase-viewer-possible-littering.json
@@ -1,0 +1,41 @@
+{
+  "id": "purchase-viewer-possible-littering",
+  "name": "PurchaseViewer VC for home/event/possible_littering",
+  "purpose": "Verify the wallet holds a PurchaseViewerVC bound to a Merchandise.Purchase tx for the possible_littering dataset.",
+  "iw3ip_dataset_id": "home/event/possible_littering",
+  "iw3ip_vc_kind": "PurchaseViewerVC",
+  "input_descriptors": [
+    {
+      "id": "purchase_viewer_vc_possible_littering",
+      "name": "PurchaseViewerVC (possible_littering)",
+      "format": {
+        "vc+sd-jwt": {
+          "sd-jwt_alg_values": ["ES256"],
+          "kb-jwt_alg_values": ["ES256"]
+        },
+        "dc+sd-jwt": {
+          "sd-jwt_alg_values": ["ES256"],
+          "kb-jwt_alg_values": ["ES256"]
+        }
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": ["$.vct"],
+            "filter": {
+              "type": "string",
+              "const": "https://iw3ip.example/credentials/PurchaseViewerVC/v1"
+            }
+          },
+          {
+            "path": ["$.dataset_id"],
+            "filter": {
+              "type": "string",
+              "const": "home/event/possible_littering"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -404,10 +404,18 @@ def marketplace_claim(body: dict, request: _Request) -> dict:
         # Reserve an Offer entry so /issuer/token can find the
         # pre_authorized_code we just minted. M3: PurchaseViewerVC
         # binds merchandise + tx + buyer_eth_addr to the issued credential.
+        # Stage T (case alpha) — pick a tier-aware credential_configuration_id
+        # so the wallet renders three distinct cards (Full / Image / Event-only).
+        from publisher.app.ssi.issuer_routes import (
+            purchase_viewer_config_id_for_access_level,
+        )
+        tier_cfg_id = purchase_viewer_config_id_for_access_level(
+            claim.access_level
+        )
         ssi_state._offers[claim.pre_authorized_code] = (  # noqa: SLF001
             __import__("publisher.app.ssi.state", fromlist=["Offer"]).Offer(
                 pre_authorized_code=claim.pre_authorized_code,
-                credential_config_id="PurchaseViewerVC",
+                credential_config_id=tier_cfg_id,
                 dataset_id=claim.dataset_id,
                 purpose="read",
                 allowed_purposes=["read"],
@@ -432,9 +440,18 @@ def marketplace_claim(body: dict, request: _Request) -> dict:
         )
 
     public_base = externally_reachable_base_url(request, ssi_settings.issuer_base_url)
+    # Stage T (case alpha) — point the deeplink at the tier-aware config id
+    # so the wallet labels the resulting card as Full / Image / Event-only.
+    if created:
+        deeplink_cfg_id = tier_cfg_id  # noqa: F821 — defined in `if created` above
+    else:
+        from publisher.app.ssi.issuer_routes import (
+            purchase_viewer_config_id_for_access_level as _resolve_cfg,
+        )
+        deeplink_cfg_id = _resolve_cfg(claim.access_level)
     co = {
         "credential_issuer": public_base,
-        "credential_configuration_ids": ["PurchaseViewerVC"],
+        "credential_configuration_ids": [deeplink_cfg_id],
         "grants": {
             "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
                 "pre-authorized_code": claim.pre_authorized_code,

--- a/publisher/app/pipeline.py
+++ b/publisher/app/pipeline.py
@@ -77,6 +77,22 @@ class MessageProcessor:
             "publisher_id": self.publisher_id,
         }
 
+        # Stage T (case alpha) — hoist trust-tier-relevant media fields
+        # (image_cid / video_cid / video_duration_sec) to the envelope's
+        # top level. /platform/data's allowed_views projection filters
+        # those keys per tier; without this hoist, /simulate/publish
+        # buries them inside `payload.payload.data` and the projection
+        # never bites.
+        for _media_key in ("image_cid", "video_cid", "video_duration_sec"):
+            if not isinstance(payload, dict):
+                break
+            if _media_key in payload:
+                envelope.setdefault(_media_key, payload[_media_key])
+                continue
+            inner = payload.get("data")
+            if isinstance(inner, dict) and _media_key in inner:
+                envelope.setdefault(_media_key, inner[_media_key])
+
         try:
             self.platform_client.send(envelope)
             self.audit_repo.write(

--- a/publisher/app/ssi/issuer_routes.py
+++ b/publisher/app/ssi/issuer_routes.py
@@ -28,6 +28,33 @@ SERVICE_VC_CONFIG_ID = "ServiceVC"
 SERVICE_VCT = "https://iw3ip.example/credentials/ServiceVC/v1"
 PURCHASE_VIEWER_VC_CONFIG_ID = "PurchaseViewerVC"
 PURCHASE_VIEWER_VCT = "https://iw3ip.example/credentials/PurchaseViewerVC/v1"
+# Stage T (case alpha) — tier-aware credential_configuration_ids so the
+# wallet renders three distinct cards (Full / Image / Event-only) for the
+# same VCT. The wallet's credential list shows display.name from these
+# entries; without the split, all three look identical.
+PURCHASE_VIEWER_VC_CONFIG_ID_FULL = "PurchaseViewerVC.full"
+PURCHASE_VIEWER_VC_CONFIG_ID_ACCESS = "PurchaseViewerVC.access"
+PURCHASE_VIEWER_VC_CONFIG_ID_EVENT = "PurchaseViewerVC.event"
+PURCHASE_VIEWER_VC_TIERED_CONFIG_IDS = (
+    PURCHASE_VIEWER_VC_CONFIG_ID,
+    PURCHASE_VIEWER_VC_CONFIG_ID_FULL,
+    PURCHASE_VIEWER_VC_CONFIG_ID_ACCESS,
+    PURCHASE_VIEWER_VC_CONFIG_ID_EVENT,
+)
+
+
+def purchase_viewer_config_id_for_access_level(
+    access_level: str | None,
+) -> str:
+    """Map an access_level (full / access / denied / None) to the
+    tier-specific credential_configuration_id. ``None`` and unknown
+    values fall back to the event-only tier so the wallet still renders
+    something sensible."""
+    if access_level == "full":
+        return PURCHASE_VIEWER_VC_CONFIG_ID_FULL
+    if access_level == "access":
+        return PURCHASE_VIEWER_VC_CONFIG_ID_ACCESS
+    return PURCHASE_VIEWER_VC_CONFIG_ID_EVENT
 SELLER_VC_CONFIG_ID = "SellerVC"
 SELLER_VCT = "https://iw3ip.example/credentials/SellerVC/v1"
 DATA_USER_VC_CONFIG_ID = "DataUserVC"
@@ -90,6 +117,34 @@ def _credential_offer(base_url: str, pre_auth_code: str, config_id: str) -> dict
             "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
                 "pre-authorized_code": pre_auth_code,
             }
+        },
+    }
+
+
+def _purchase_viewer_config_entry(
+    common_alg: dict, *, display_en: str, display_ja: str
+) -> dict:
+    """Build a credential_configurations_supported entry for one
+    PurchaseViewerVC tier. All four entries share the VCT and claim
+    schema; only the human-readable display name differs."""
+    return {
+        **common_alg,
+        "vct": PURCHASE_VIEWER_VCT,
+        "scope": "PurchaseViewerVC",
+        "display": [
+            {"name": display_en, "locale": "en"},
+            {"name": display_ja, "locale": "ja"},
+        ],
+        "claims": {
+            "dataset_id": {"display": [{"name": "Dataset ID"}]},
+            "allowed_actions": {"display": [{"name": "Allowed actions"}]},
+            "allowed_views": {"display": [{"name": "Allowed views"}]},
+            "access_level": {"display": [{"name": "Trust tier"}]},
+            "merchandise_address": {"display": [{"name": "Merchandise contract"}]},
+            "buyer_eth_addr": {"display": [{"name": "Buyer ETH address"}]},
+            "tx_hash": {"display": [{"name": "Purchase tx hash"}]},
+            "subject_id": {"display": [{"name": "Subject"}], "mandatory": False},
+            "iw3ip_issuer": {"display": [{"name": "Issuer"}]},
         },
     }
 
@@ -189,24 +244,30 @@ def _credential_issuer_metadata(base_url: str, keys: IssuerKeyStore) -> dict:
                     "iw3ip_issuer": {"display": [{"name": "Issuer"}]},
                 },
             },
-            PURCHASE_VIEWER_VC_CONFIG_ID: {
-                **common_alg,
-                "vct": PURCHASE_VIEWER_VCT,
-                "scope": "PurchaseViewerVC",
-                "display": [
-                    {"name": "IW3IP Purchase Viewer Credential", "locale": "en"},
-                    {"name": "IW3IP 購入閲覧クレデンシャル", "locale": "ja"},
-                ],
-                "claims": {
-                    "dataset_id": {"display": [{"name": "Dataset ID"}]},
-                    "allowed_actions": {"display": [{"name": "Allowed actions"}]},
-                    "merchandise_address": {"display": [{"name": "Merchandise contract"}]},
-                    "buyer_eth_addr": {"display": [{"name": "Buyer ETH address"}]},
-                    "tx_hash": {"display": [{"name": "Purchase tx hash"}]},
-                    "subject_id": {"display": [{"name": "Subject"}], "mandatory": False},
-                    "iw3ip_issuer": {"display": [{"name": "Issuer"}]},
-                },
-            },
+            PURCHASE_VIEWER_VC_CONFIG_ID: _purchase_viewer_config_entry(
+                common_alg,
+                display_en="IW3IP Purchase Viewer Credential",
+                display_ja="IW3IP 購入閲覧クレデンシャル",
+            ),
+            # Stage T (case alpha): tier-specific entries so the wallet
+            # shows three distinct cards. All three resolve to the same
+            # VCT (PURCHASE_VIEWER_VCT); the verifier DCQL filters on the
+            # `access_level` claim, not the config_id.
+            PURCHASE_VIEWER_VC_CONFIG_ID_FULL: _purchase_viewer_config_entry(
+                common_alg,
+                display_en="IW3IP Purchase Viewer (Full • event + image + video)",
+                display_ja="IW3IP 購入閲覧（Tier 3 / 動画まで）",
+            ),
+            PURCHASE_VIEWER_VC_CONFIG_ID_ACCESS: _purchase_viewer_config_entry(
+                common_alg,
+                display_en="IW3IP Purchase Viewer (Access • event + image)",
+                display_ja="IW3IP 購入閲覧（Tier 2 / 画像まで）",
+            ),
+            PURCHASE_VIEWER_VC_CONFIG_ID_EVENT: _purchase_viewer_config_entry(
+                common_alg,
+                display_en="IW3IP Purchase Viewer (Event-only)",
+                display_ja="IW3IP 購入閲覧（Tier 1 / イベントのみ）",
+            ),
         },
         "issuer": issuer_did,
         "jwks": {"keys": [keys.public_jwk]},
@@ -467,9 +528,15 @@ def build_router(deps: IssuerDeps) -> APIRouter:
         fmt = body.get("format")
         offer_vct = VC_KIND_TO_VCT[offer.vc_kind]
         offer_cfg_id = VC_KIND_TO_CONFIG_ID[offer.vc_kind]
+        # Stage T (case alpha): for PurchaseViewerVC the offer carries one of
+        # several tier-aware config_ids (.full / .access / .event) — all valid
+        # for the same VCT, so the "exact match" check is widened.
+        valid_cfg_ids: tuple[str, ...] = (offer_cfg_id,)
+        if offer.vc_kind == "PurchaseViewerVC":
+            valid_cfg_ids = PURCHASE_VIEWER_VC_TIERED_CONFIG_IDS
         # Accept both the new (`dc+sd-jwt`) and legacy (`vc+sd-jwt`) SD-JWT VC media
         # type names so wallets that pin to either draft revision can still issue.
-        if not (cfg_id == offer_cfg_id or fmt in ("dc+sd-jwt", "vc+sd-jwt")):
+        if not (cfg_id in valid_cfg_ids or fmt in ("dc+sd-jwt", "vc+sd-jwt")):
             raise HTTPException(status_code=400, detail=f"only sd-jwt vc supported (got format={fmt}, cfg_id={cfg_id})")
         if body.get("vct") and body["vct"] != offer_vct:
             raise HTTPException(status_code=400, detail=f"unknown vct: {body['vct']}")
@@ -524,6 +591,14 @@ def build_router(deps: IssuerDeps) -> APIRouter:
                     # buyer can see what they paid for, and so verifier
                     # presentation surfaces it back to the publisher.
                     "allowed_views": claim.allowed_views,
+                    # Tier-aware display: surface access_level and
+                    # trust_score so the wallet detail screen shows
+                    # which tier this card represents (e.g. "full" /
+                    # "access") even when three cards share a VCT.
+                    "access_level": claim.access_level or "event",
+                    "trust_score": claim.trust_score
+                    if claim.trust_score is not None
+                    else 0,
                 })
                 deps.state.attach_holder_to_claim(claim.claim_id, holder_did)
                 # Audit the eth_addr <-> did:jwk binding now that we have both.

--- a/tests/test_data_user_vc_tiered.py
+++ b/tests/test_data_user_vc_tiered.py
@@ -478,6 +478,151 @@ def test_issuer_offer_unknown_claim_id_404(client):
     assert "unknown claim_id" in r.json()["detail"]
 
 
+def test_pipeline_hoists_media_cids_to_top_level():
+    """Stage T (case alpha): /platform/data's allowed_views projection
+    only filters top-level keys. The pipeline must hoist image_cid /
+    video_cid / video_duration_sec out of the inbound payload so the
+    projection bites at Tier 2 / Tier 3.
+
+    Tested at the MessageProcessor level so the test does not depend on
+    a reachable platform/ingest endpoint.
+    """
+    from datetime import datetime, timezone, timedelta
+    from publisher.app.pipeline import MessageProcessor
+    from policy.engine import PolicyEngine
+    from policy.store import ConsentStore
+    from audit.repository import SQLiteAuditRepository
+    from policy.models import ConsentVC
+    import tempfile
+    import os
+
+    captured: list[dict] = []
+
+    class _FakePlatformClient:
+        def send(self, envelope: dict) -> None:
+            captured.append(envelope)
+
+    with tempfile.TemporaryDirectory() as td:
+        consent_store = ConsentStore(os.path.join(td, "consents.json"))
+        now = datetime.now(timezone.utc)
+        consent_store.upsert(
+            ConsentVC(
+                vc_id="c-tier-test",
+                subject_did="did:example:park",
+                dataset_id="home/event/possible_littering",
+                allowed_purposes=["community_cleaning"],
+                retention_days=14,
+                reshare_allowed=False,
+                valid_from=now - timedelta(days=1),
+                valid_to=now + timedelta(days=30),
+                signature="x",
+            )
+        )
+        audit_repo = SQLiteAuditRepository(os.path.join(td, "audit.db"))
+        proc = MessageProcessor(
+            publisher_id="test",
+            default_purpose="community_cleaning",
+            consent_store=consent_store,
+            policy_engine=PolicyEngine(),
+            audit_repo=audit_repo,
+            platform_client=_FakePlatformClient(),
+        )
+        result = proc.process_message(
+            "homeassistant/event/possible_littering",
+            {
+                "event_type": "possible_littering",
+                "ts": "2026-04-29T09:00:00Z",
+                "source": "edge_inference",
+                "image_cid": "QmTopLevelImage",
+                "data": {
+                    "video_cid": "QmNestedVideo",
+                    "video_duration_sec": 7,
+                },
+            },
+            "community_cleaning",
+        )
+        assert result["status"] == "allowed", result
+        assert captured, "platform_client.send was not called"
+        env = captured[-1]
+        assert env.get("image_cid") == "QmTopLevelImage", env
+        assert env.get("video_cid") == "QmNestedVideo", env
+        assert env.get("video_duration_sec") == 7, env
+
+
+def test_marketplace_claim_picks_tier_aware_config_id(client):
+    """Stage T (case alpha): the deeplink emitted by /marketplace/claim
+    must reference the tier-specific credential_configuration_id so the
+    wallet renders three distinct cards (Full / Image / Event-only)
+    rather than three identical "PurchaseViewerVC" entries."""
+    tc, _ = client
+
+    cases = [
+        (
+            {
+                "entityType": "GovernmentOrganization",
+                "purpose": "research",
+                "legalCompliance": True,
+                "dataHandlingPolicy": "ISO27001",
+                "misuseRecord": False,
+            },
+            "PurchaseViewerVC.full",
+        ),
+        (
+            {
+                "entityType": "Enterprise",
+                "purpose": "research",
+                "legalCompliance": True,
+                "dataHandlingPolicy": "ISO27001",
+                "misuseRecord": False,
+            },
+            "PurchaseViewerVC.access",
+        ),
+        (None, "PurchaseViewerVC.event"),
+    ]
+    for i, (attrs, expected_cfg_id) in enumerate(cases):
+        body: dict = {
+            "merchandise_address": f"0x{i:040x}",
+            "buyer_eth_addr": f"0x{(i+100):040x}",
+            "tx_hash": f"0x{(i+200):064x}",
+            "dataset_id": "home/env/temperature",
+        }
+        if attrs:
+            body["data_user_attrs"] = attrs
+        resp = tc.post("/marketplace/claim", json=body).json()
+        co = json.loads(__import__("urllib.parse").parse.unquote(
+            resp["deeplink"].split("=", 1)[1]
+        ))
+        assert co["credential_configuration_ids"] == [expected_cfg_id], (
+            f"case {i}: expected deeplink config_id {expected_cfg_id!r}, "
+            f"got {co['credential_configuration_ids']!r}"
+        )
+
+
+def test_issuer_metadata_lists_three_purchase_viewer_tiers(client):
+    tc, _ = client
+    md = tc.get("/.well-known/openid-credential-issuer").json()
+    cfgs = md["credential_configurations_supported"]
+    for cfg_id in (
+        "PurchaseViewerVC",
+        "PurchaseViewerVC.full",
+        "PurchaseViewerVC.access",
+        "PurchaseViewerVC.event",
+    ):
+        assert cfg_id in cfgs, cfgs.keys()
+        assert cfgs[cfg_id]["vct"] == "https://iw3ip.example/credentials/PurchaseViewerVC/v1"
+    # The three tiered entries must have distinct display names so the
+    # wallet renders distinct cards.
+    names = {
+        cfg_id: cfgs[cfg_id]["display"][0]["name"]
+        for cfg_id in (
+            "PurchaseViewerVC.full",
+            "PurchaseViewerVC.access",
+            "PurchaseViewerVC.event",
+        )
+    }
+    assert len(set(names.values())) == 3, names
+
+
 def test_purchase_viewer_vc_includes_subject_id(client):
     """Regression for "No Available Credential" in iw3ip-wallet: the
     verifier DCQL requires `subject_id`, so the issuer must bake the


### PR DESCRIPTION
## Summary

UX + integration polish from the iPhone real-device validation of Stage T case alpha. Three small, tightly scoped changes:

### 1. Tier-aware credential_configuration_ids for PurchaseViewerVC

Before: the wallet rendered three identical "PurchaseViewerVC" cards for the three Tier outcomes (Full / Image / Event-only) — no way to tell them apart without opening the detail.

After: alongside the legacy `PurchaseViewerVC` entry, the issuer metadata now exposes three tier-specific entries — `PurchaseViewerVC.full` / `.access` / `.event` — all backed by the same VCT, each with a distinct display name (JA + EN). `/marketplace/claim` picks the right one from `claim.access_level` and bakes it into both the deeplink and the stashed `Offer`. `/issuer/credential` accepts any of the three. The issued VC also gains `access_level` and `trust_score` as plain claims so the wallet detail surfaces which tier this card represents.

### 2. Hoist media CIDs in the ingest pipeline

`/platform/data`'s `allowed_views` projection only filters top-level keys. `/simulate/publish` was burying `image_cid` / `video_cid` / `video_duration_sec` inside `payload.payload.data`, so the projection never bit — only direct `/platform/ingest` calls produced rows that showed tier differences. The pipeline now hoists those three keys to the envelope's top level so `/simulate/publish` drives the projection identically to `/platform/ingest`.

### 3. Add the PurchaseViewerVC PD for `home/event/possible_littering`

The Stage T hands-on uses `dataset_id=home/event/possible_littering`, but the repo only shipped a PD for `home/env/temperature`, so the walkthrough relied on a runtime PD injection. This PR adds `examples/ssi_wallet/purchase-viewer-possible-littering.json` (declaring both `vc+sd-jwt` and `dc+sd-jwt` formats) so the walkthrough works out of the box.

## Tests

```
uv run pytest -q
# 94 passed (91 existing + 3 new)
```

The 3 new tests in `tests/test_data_user_vc_tiered.py`:
- `test_pipeline_hoists_media_cids_to_top_level` — pipeline-level test (does not depend on a reachable `/platform/ingest` endpoint)
- `test_marketplace_claim_picks_tier_aware_config_id` — `/marketplace/claim` deeplink references the right tier-aware id
- `test_issuer_metadata_lists_three_purchase_viewer_tiers` — issuer metadata exposes the three tier-specific entries with distinct display names

## Backward compatibility

- The legacy `PurchaseViewerVC` config_id stays in the metadata. Older wallets / fixtures that hard-code that string keep working.
- The legacy `format=vc+sd-jwt` token also still works, because `/issuer/credential` widens the `cfg_id ∈ valid_cfg_ids OR fmt ∈ {dc+sd-jwt, vc+sd-jwt}` check rather than tightening it.

## Test plan
- [ ] iPhone real-device: rerun the Stage T walkthrough and confirm three distinct cards show in the wallet (Tier 3 / 2 / 1) with different display names.
- [ ] `/simulate/publish` (with `image_cid` / `video_cid` either at top level or under `data:`) drives `/platform/data` projection differences without needing `/platform/ingest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
