### PR TITLE
feat(media): Stage T case B - HTTP media gateway + URL-based projection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ site/
 __pycache__/
 *.pyc
 .venv-ssi/
+
+# Stage T (case B): default media gateway store dir
+publisher/data/

--- a/examples/hands_on/common.py
+++ b/examples/hands_on/common.py
@@ -44,3 +44,54 @@ def detect_lan_ip() -> str:
         return sock.getsockname()[0]
     finally:
         sock.close()
+
+
+def upload_media(
+    base_url: str,
+    file_path: Path,
+    *,
+    content_type: str | None = None,
+) -> dict:
+    """POST a binary blob to /media/upload and return the JSON response.
+
+    Used by the Stage T (case B) hands-on flow so a data provider can
+    bake an ``image_url`` / ``video_url`` into the event payload before
+    sending it to the publisher. The publisher's media gateway dedupes
+    on sha256 so repeated uploads of the same fixture are cheap.
+    """
+    import mimetypes
+    import uuid
+
+    body_bytes = file_path.read_bytes()
+    if content_type is None:
+        content_type = (
+            mimetypes.guess_type(file_path.name)[0] or "application/octet-stream"
+        )
+    boundary = "----iw3ip-" + uuid.uuid4().hex
+    crlf = b"\r\n"
+    parts: list[bytes] = []
+    parts.append(f"--{boundary}".encode())
+    parts.append(
+        (
+            f'Content-Disposition: form-data; name="file"; '
+            f'filename="{file_path.name}"'
+        ).encode()
+    )
+    parts.append(f"Content-Type: {content_type}".encode())
+    parts.append(b"")
+    parts.append(body_bytes)
+    parts.append(f"--{boundary}--".encode())
+    parts.append(b"")
+    body = crlf.join(parts)
+
+    req = request.Request(
+        base_url.rstrip("/") + "/media/upload",
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+            "Content-Length": str(len(body)),
+        },
+    )
+    with request.urlopen(req, timeout=30) as resp:  # noqa: S310 - local training endpoint
+        return json.load(resp)

--- a/examples/hands_on/data_user_vc_tiered/README.md
+++ b/examples/hands_on/data_user_vc_tiered/README.md
@@ -1,0 +1,41 @@
+# Stage T case B — provider-with-media demo
+
+Drives the full **"event + image + video → tier-aware `/platform/data`"**
+loop. The receiver side is unchanged — Tier 3 sees `image_url` and
+`video_url`, Tier 2 sees only `image_url`, Tier 1 sees neither.
+
+```bash
+# Provider side
+python examples/hands_on/data_user_vc_tiered/provider_with_media.py \
+  --base-url http://192.168.68.53:8080
+```
+
+The script:
+
+1. Generates a 1×1 JPEG / MP4 fixture under `fixtures/` (or uses
+   `--image` / `--video` paths you supply).
+2. Uploads both via `POST /media/upload` (the publisher's media gateway
+   dedupes on sha256, so re-runs are cheap).
+3. Builds a `possible_littering` event with `image_url` / `video_url` /
+   `video_duration_sec` at the envelope top level.
+4. Posts it to `/simulate/publish` so it runs through the same Consent
+   VC pipeline as the Phase 2 hands-on.
+
+## Receiver (unchanged)
+
+Use the existing Stage T walkthrough at
+`docs/hands-on/data-user-vc-tiered.md` — issue a DataUserVC at the
+desired tier, claim, present a PurchaseViewerVC, fetch
+`/platform/data`, and watch `image_url` / `video_url` appear or
+disappear per tier. Tap the URL on the receiver's browser / wallet to
+see the actual blob.
+
+## Limitations (intentional, lifted in case C)
+
+- Publisher-hosted, not content-addressed.
+- No auth on the GET path: the URL itself is the only access control
+  (sha256 makes it unguessable, but URL-leakage = blob-leakage).
+- Single replica: no resilience / pinning.
+
+Case C will replace the gateway with IPFS / Web3.Storage while keeping
+the same `/media/upload` shape so this script doesn't change.

--- a/examples/hands_on/data_user_vc_tiered/provider_with_media.py
+++ b/examples/hands_on/data_user_vc_tiered/provider_with_media.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Stage T (case B) — provider-side script that drives the full
+"event + image + video → tier-aware /platform/data" loop.
+
+Steps it runs end-to-end:
+
+  1. Generate a small JPEG and a small MP4 fixture (or take user-supplied
+     paths) and POST them to ``/media/upload``. The publisher dedupes on
+     sha256, so repeat runs are cheap.
+  2. Build a `possible_littering` event payload that carries
+     ``image_url`` / ``video_url`` / ``video_duration_sec`` at the top
+     level **and** under ``data:`` (the pipeline hoists either form,
+     this just shows both work).
+  3. POST the payload to ``/simulate/publish`` so it runs through the
+     same Consent VC pipeline the Phase 2 hands-on use.
+
+The receiver side (Tier 3 / 2 / 1 wallets) is unchanged — they simply
+get ``image_url`` / ``video_url`` keys at ``/platform/data`` according
+to their tier projection, and can dereference the URL directly with the
+buyer's browser / wallet.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.hands_on.common import post_json, upload_media
+
+
+# Smallest legal JPEG (1×1 white pixel, 125 bytes).
+_TINY_JPEG = bytes.fromhex(
+    "ffd8ffe000104a46494600010100000100010000ffdb004300080606070605"
+    "08070707090908090a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"
+    "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0affc0000b08"
+    "00010001010100ffc4001500010100000000000000000000000000000007ff"
+    "c4001f10000103030301010100000000000000010002030405060708ffd900"
+)
+
+
+def _ensure_fixture(path: Path, blob: bytes) -> Path:
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(blob)
+    return path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://localhost:8080")
+    parser.add_argument("--purpose", default="community_cleaning")
+    parser.add_argument(
+        "--image",
+        type=Path,
+        help="JPEG/PNG to upload as the `image_url`. Defaults to a 1×1 fixture.",
+    )
+    parser.add_argument(
+        "--video",
+        type=Path,
+        help="MP4 to upload as the `video_url`. Defaults to the 1×1 JPEG bytes "
+        "tagged as video/mp4 — fine for tier-projection demos, replace with a "
+        "real clip for a production-flavoured run.",
+    )
+    parser.add_argument("--video-duration-sec", type=int, default=12)
+    parser.add_argument("--camera-id", default="webcam-401")
+    args = parser.parse_args()
+
+    # 1) Resolve / generate fixtures.
+    image_path = args.image or _ensure_fixture(
+        REPO_ROOT
+        / "examples"
+        / "hands_on"
+        / "data_user_vc_tiered"
+        / "fixtures"
+        / "stage_t_demo.jpg",
+        _TINY_JPEG,
+    )
+    # For demos that don't have a real video clip, reuse the JPEG bytes
+    # behind a video/* extension so the upload codepath exercises both
+    # branches. The Tier projection only cares about the URL keys.
+    video_path = args.video or _ensure_fixture(
+        REPO_ROOT
+        / "examples"
+        / "hands_on"
+        / "data_user_vc_tiered"
+        / "fixtures"
+        / "stage_t_demo.mp4",
+        _TINY_JPEG,
+    )
+
+    # 2) Upload both blobs to /media/upload.
+    img_resp = upload_media(args.base_url, image_path, content_type="image/jpeg")
+    vid_resp = upload_media(args.base_url, video_path, content_type="video/mp4")
+    print("[upload]", json.dumps({"image": img_resp, "video": vid_resp}, indent=2))
+
+    # 3) Build the event payload. The pipeline hoists either form.
+    payload = {
+        "event_type": "possible_littering",
+        "data": {
+            "camera_id": args.camera_id,
+            "object_class": "bottle",
+            "confidence": 0.87,
+        },
+        "image_url": img_resp["url"],
+        "video_url": vid_resp["url"],
+        "video_duration_sec": args.video_duration_sec,
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "source": "edge_inference",
+    }
+
+    body = {
+        "topic": "homeassistant/event/possible_littering",
+        "payload": payload,
+        "purpose": args.purpose,
+    }
+    result = post_json(args.base_url, "/simulate/publish", body)
+    print("[publish]", json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -23,6 +23,9 @@ services:
       PUBLISHER_ID: publisher-001
       AUDIT_DB_PATH: /data/audit.db
       CONSENT_STORE_PATH: /data/consents.json
+      # Stage T (case B): media gateway store + (optional) public base URL
+      MEDIA_STORE_PATH: /data/media
+      MEDIA_PUBLIC_BASE_URL: ${MEDIA_PUBLIC_BASE_URL:-}
       SSI_ISSUER_BASE_URL: ${SSI_ISSUER_BASE_URL:-http://publisher:8080}
       SSI_ISSUER_KEY_PATH: /data/issuer_key.jwk.json
       SSI_PEX_SIDECAR_URL: http://verifier-sidecar:7000

--- a/publisher/app/config.py
+++ b/publisher/app/config.py
@@ -18,6 +18,17 @@ class Settings(BaseSettings):
     audit_db_path: str = "audit/audit.db"
     consent_store_path: str | None = None
 
+    # Stage T (case B): static directory the media gateway writes uploaded
+    # image/video blobs into and serves them from at /media/<sha256>.<ext>.
+    # Production callers (docker compose) should override this to a real
+    # volume mount such as /data/media; the relative default is so the
+    # publisher boots fine in the test environment without sudo.
+    media_store_path: str = "publisher/data/media"
+    # Public base URL the wallet / browser uses to GET /media/<name>. When
+    # left empty we mint a relative path so the wallet/browser inherits the
+    # same origin it fetched the platform data from.
+    media_public_base_url: str = ""
+
     # Stage 7 (case C): when set, /marketplace/register verifies that
     # Merchandise.getOwner() == seller_eth_addr against this RPC. Leave
     # unset in tests/dev to skip the check (and in audit log we'll mark

--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -15,6 +15,7 @@ from publisher.app.models import SimulatePublishRequest
 from publisher.app.mqtt_subscriber import MQTTSubscriber
 from publisher.app.pipeline import MessageProcessor
 from publisher.app.platform_client import PlatformClient
+from publisher.app.media_routes import build_router as build_media_router
 from publisher.app.ssi import issuer_routes, verifier_routes
 from publisher.app.ssi.config import SSISettings
 from publisher.app.ssi.keys import IssuerKeyStore
@@ -97,6 +98,15 @@ app.include_router(
             audit_repo=audit_repo,
             pex_client=ssi_pex_client,
         )
+    )
+)
+# Stage T (case B): media gateway. POST /media/upload writes the blob,
+# GET /media/<sha>.<ext> serves it. Tier-aware projection in
+# /platform/data already filters image_url / video_url per tier.
+app.include_router(
+    build_media_router(
+        store_path=settings.media_store_path,
+        public_base_url=settings.media_public_base_url,
     )
 )
 
@@ -295,14 +305,19 @@ def platform_data(
     # never leak.
     allowed_views = vt.allowed_views or ["event"]
 
+    # Stage T (case B): media URLs (image_url / video_url) are filtered
+    # alongside the legacy CID keys. The two coexist so the same row can
+    # carry both an IPFS CID (Stage T case C) and a publisher-hosted
+    # URL during migration.
+    _IMAGE_KEYS = ("image_cid", "image_url")
+    _VIDEO_KEYS = ("video_cid", "video_url", "video_duration_sec")
+
     def _project(row: dict) -> dict:
         out: dict = {}
         for k, v in row.items():
-            if k == "image_cid" and "image" not in allowed_views:
+            if k in _IMAGE_KEYS and "image" not in allowed_views:
                 continue
-            if k == "video_cid" and "video" not in allowed_views:
-                continue
-            if k == "video_duration_sec" and "video" not in allowed_views:
+            if k in _VIDEO_KEYS and "video" not in allowed_views:
                 continue
             out[k] = v
         return out

--- a/publisher/app/media_routes.py
+++ b/publisher/app/media_routes.py
@@ -1,0 +1,132 @@
+"""Stage T (case B) — minimal HTTP media gateway.
+
+Lets the data-provider side stash a JPEG / MP4 blob and get back a
+stable URL it can fold into the event payload as ``image_url`` /
+``video_url``. The Phase 2 publisher then runs the same tier-aware
+``/platform/data`` projection on those URL keys that it already runs on
+``image_cid`` / ``video_cid``.
+
+This is **not** a content-addressed store — the wallet just dereferences
+the URL like any other static asset. Case C will replace it with a real
+IPFS / Web3.Storage backend; the API surface here (POST /media/upload
+returning a JSON ``{url, sha256, content_type, byte_size}``) is the same
+shape, so callers shouldn't need to change.
+
+Storage layout::
+
+    <media_store_path>/<sha256>.<ext>
+
+The sha256 doubles as the filename so duplicates dedupe automatically.
+
+Security: ``/media/<sha256>.<ext>`` is unauthenticated **on purpose** —
+the wallet running on the buyer's iPhone must be able to fetch it after
+the tier-aware projection hands the URL out. Authorization is enforced
+upstream at ``/platform/data`` (ViewerToken + ``allowed_views``).
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import mimetypes
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, UploadFile, File, Request
+from fastapi.responses import FileResponse, JSONResponse
+
+
+logger = logging.getLogger(__name__)
+
+
+_ALLOWED_EXT = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".m4v": "video/mp4",
+}
+
+
+def _resolve_ext(filename: str | None, content_type: str | None) -> str:
+    if filename:
+        ext = Path(filename).suffix.lower()
+        if ext in _ALLOWED_EXT:
+            return ext
+    if content_type:
+        ext = mimetypes.guess_extension(content_type) or ""
+        if ext.lower() in _ALLOWED_EXT:
+            return ext.lower()
+    raise HTTPException(
+        status_code=415,
+        detail=(
+            "unsupported media type; expected one of "
+            + ", ".join(sorted(_ALLOWED_EXT))
+        ),
+    )
+
+
+def build_router(*, store_path: str, public_base_url: str = "") -> APIRouter:
+    """Return a router with /media/upload (POST) + /media/{name} (GET).
+
+    ``public_base_url`` is prefixed onto the URL we hand back. When empty
+    we hand back a relative ``/media/<name>`` so callers inherit the
+    request's own origin (this is what the dockerised tests exercise).
+    """
+    base = Path(store_path)
+    base.mkdir(parents=True, exist_ok=True)
+
+    router = APIRouter()
+
+    @router.post("/media/upload")
+    async def media_upload(
+        request: Request,
+        file: UploadFile = File(...),
+    ) -> JSONResponse:
+        ext = _resolve_ext(file.filename, file.content_type)
+        body = await file.read()
+        if not body:
+            raise HTTPException(status_code=400, detail="empty_body")
+        sha = hashlib.sha256(body).hexdigest()
+        name = f"{sha}{ext}"
+        path = base / name
+        if not path.exists():
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_bytes(body)
+            tmp.replace(path)
+        # Mint URL. When media_public_base_url is set we use it verbatim;
+        # otherwise we fall back to the request origin so the wallet on
+        # the buyer's phone reaches us at the same hostname.
+        if public_base_url:
+            url = f"{public_base_url.rstrip('/')}/media/{name}"
+        else:
+            origin = str(request.base_url).rstrip("/")
+            url = f"{origin}/media/{name}"
+        logger.info(
+            "media_uploaded sha256=%s ext=%s bytes=%d url=%s",
+            sha[:16] + "...",
+            ext,
+            len(body),
+            url,
+        )
+        return JSONResponse(
+            {
+                "url": url,
+                "sha256": sha,
+                "content_type": _ALLOWED_EXT[ext],
+                "byte_size": len(body),
+            }
+        )
+
+    @router.get("/media/{name}")
+    def media_get(name: str) -> FileResponse:
+        # Reject directory traversal / dotted segments.
+        if "/" in name or "\\" in name or name.startswith("."):
+            raise HTTPException(status_code=400, detail="bad_name")
+        path = base / name
+        if not path.is_file():
+            raise HTTPException(status_code=404, detail="not_found")
+        return FileResponse(path)
+
+    return router

--- a/publisher/app/pipeline.py
+++ b/publisher/app/pipeline.py
@@ -77,13 +77,21 @@ class MessageProcessor:
             "publisher_id": self.publisher_id,
         }
 
-        # Stage T (case alpha) — hoist trust-tier-relevant media fields
-        # (image_cid / video_cid / video_duration_sec) to the envelope's
-        # top level. /platform/data's allowed_views projection filters
-        # those keys per tier; without this hoist, /simulate/publish
-        # buries them inside `payload.payload.data` and the projection
-        # never bites.
-        for _media_key in ("image_cid", "video_cid", "video_duration_sec"):
+        # Stage T (case alpha + B) — hoist trust-tier-relevant media
+        # fields to the envelope's top level. /platform/data's
+        # allowed_views projection filters these keys per tier; without
+        # this hoist /simulate/publish would bury them inside
+        # `payload.payload.data` and the projection never bites.
+        # `image_url` / `video_url` are case B (publisher-hosted media
+        # gateway); `image_cid` / `video_cid` are case alpha + the
+        # forthcoming case C (real IPFS).
+        for _media_key in (
+            "image_cid",
+            "image_url",
+            "video_cid",
+            "video_url",
+            "video_duration_sec",
+        ):
             if not isinstance(payload, dict):
                 break
             if _media_key in payload:

--- a/tests/test_data_user_vc_tiered.py
+++ b/tests/test_data_user_vc_tiered.py
@@ -10,6 +10,7 @@ Verifies:
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import time
 from pathlib import Path
@@ -119,6 +120,10 @@ def client(monkeypatch, tmp_path):
     monkeypatch.setenv("MQTT_BROKER_HOST", "localhost")
     monkeypatch.setenv("MQTT_TOPICS", "")
     monkeypatch.setenv("SSI_PEX_SIDECAR_URL", "http://127.0.0.1:1")
+    # Stage T (case B): keep the media gateway store inside tmp_path so
+    # the test never writes to /data/media on the host.
+    monkeypatch.setenv("MEDIA_STORE_PATH", str(tmp_path / "media"))
+    monkeypatch.setenv("MEDIA_PUBLIC_BASE_URL", "")
 
     import importlib
     import publisher.app.main as pm
@@ -204,7 +209,7 @@ def _proof(priv, pub, nonce, aud):
     return h + "." + p + "." + _b64u(sig)
 
 
-def _purchase_viewer_token(tc, *, allowed_views_in_claim: list[str]):
+def _purchase_viewer_token(tc, *, allowed_views_in_claim: list[str], tx_seed: str = "66"):
     """End-to-end: claim with given views → receive PurchaseViewerVC →
     present → returned ViewerToken should carry allowed_views."""
     # Use trust_score-derived allowed_views via data_user_attrs.
@@ -231,7 +236,7 @@ def _purchase_viewer_token(tc, *, allowed_views_in_claim: list[str]):
     body: dict = {
         "merchandise_address": "0x" + "44" * 20,
         "buyer_eth_addr": "0x" + "55" * 20,
-        "tx_hash": "0x" + "66" * 32,
+        "tx_hash": "0x" + tx_seed * 32,
         "dataset_id": "home/env/temperature",
     }
     if attrs:
@@ -692,3 +697,185 @@ def test_purchase_viewer_vc_includes_subject_id(client):
         f"({holder_did!r}); got top={body_claims.get('subject_id')!r}, "
         f"disclosed={disclosed.get('subject_id')!r}"
     )
+
+
+# ---- Stage T case B: media gateway + URL-based tier projection ----
+
+
+def _tiny_jpeg() -> bytes:
+    # 1×1 white-pixel JPEG (smallest legal JPEG; 125 bytes).
+    return bytes.fromhex(
+        "ffd8ffe000104a46494600010100000100010000ffdb004300080606070605"
+        "08070707090908090a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"
+        "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0affc0000b08"
+        "00010001010100ffc4001500010100000000000000000000000000000007ff"
+        "c4001f10000103030301010100000000000000010002030405060708ffd900"
+    )
+
+
+def _multipart_body(filename: str, content_type: str, blob: bytes) -> tuple[bytes, str]:
+    boundary = "----iw3ip-test-boundary"
+    crlf = b"\r\n"
+    parts = [
+        f"--{boundary}".encode(),
+        f'Content-Disposition: form-data; name="file"; filename="{filename}"'.encode(),
+        f"Content-Type: {content_type}".encode(),
+        b"",
+        blob,
+        f"--{boundary}--".encode(),
+        b"",
+    ]
+    body = crlf.join(parts)
+    return body, f"multipart/form-data; boundary={boundary}"
+
+
+def test_media_upload_then_serve(client):
+    tc, _ = client
+    blob = _tiny_jpeg()
+    body, ct = _multipart_body("frame.jpg", "image/jpeg", blob)
+    r = tc.post("/media/upload", content=body, headers={"Content-Type": ct})
+    assert r.status_code == 200, r.text
+    j = r.json()
+    assert j["sha256"] == hashlib.sha256(blob).hexdigest()
+    assert j["content_type"] == "image/jpeg"
+    assert j["byte_size"] == len(blob)
+    assert j["url"].endswith(f"/media/{j['sha256']}.jpg")
+
+    # The published URL should resolve. TestClient sees the full origin.
+    relative = "/media/" + j["sha256"] + ".jpg"
+    r2 = tc.get(relative)
+    assert r2.status_code == 200
+    assert r2.content == blob
+    assert r2.headers["content-type"].startswith("image/jpeg")
+
+
+def test_media_upload_dedupes_on_sha256(client):
+    tc, _ = client
+    blob = _tiny_jpeg()
+    body, ct = _multipart_body("a.jpg", "image/jpeg", blob)
+    r1 = tc.post("/media/upload", content=body, headers={"Content-Type": ct}).json()
+    body2, _ = _multipart_body("b-different-name.jpg", "image/jpeg", blob)
+    r2 = tc.post("/media/upload", content=body2, headers={"Content-Type": ct}).json()
+    assert r1["sha256"] == r2["sha256"]
+    assert r1["url"] == r2["url"]
+
+
+def test_media_upload_rejects_unknown_extension(client):
+    tc, _ = client
+    body, ct = _multipart_body("payload.exe", "application/octet-stream", b"\x00" * 32)
+    r = tc.post("/media/upload", content=body, headers={"Content-Type": ct})
+    assert r.status_code == 415
+
+
+def test_media_get_rejects_path_traversal(client):
+    tc, _ = client
+    # urls with embedded slashes never match the path; this is a belt-and-braces check
+    r = tc.get("/media/..%2Fauth")
+    assert r.status_code in (400, 404)
+
+
+def test_platform_data_projects_image_url_video_url_per_tier(client):
+    """The Tier 2 / 3 buyer should see image_url; only Tier 3 should
+    additionally see video_url. Tier 1 sees neither."""
+    tc, pm = client
+    # Seed a row that uses URL-based media (case B), not CID-based.
+    pm.app.state.ingested.append({
+        "dataset_id": "home/env/temperature",
+        "event_type": "tick",
+        "data": {"value": 9},
+        "image_url": "http://testserver/media/aaaaaaa.jpg",
+        "video_url": "http://testserver/media/bbbbbbb.mp4",
+        "video_duration_sec": 4,
+    })
+
+    # Tier 3 — full
+    presented = _purchase_viewer_token(
+        tc, allowed_views_in_claim=["event", "image", "video"], tx_seed="71"
+    )
+    body = tc.get(
+        "/platform/data",
+        params={"dataset_id": "home/env/temperature"},
+        headers={"Authorization": f"Bearer {presented['viewer_token']}"},
+    ).json()
+    row = body["rows"][0]
+    assert row.get("image_url", "").endswith("/aaaaaaa.jpg")
+    assert row.get("video_url", "").endswith("/bbbbbbb.mp4")
+    assert row.get("video_duration_sec") == 4
+
+    # Tier 2 — image only (different tx_seed → fresh claim/offer)
+    presented2 = _purchase_viewer_token(
+        tc, allowed_views_in_claim=["event", "image"], tx_seed="72"
+    )
+    body2 = tc.get(
+        "/platform/data",
+        params={"dataset_id": "home/env/temperature"},
+        headers={"Authorization": f"Bearer {presented2['viewer_token']}"},
+    ).json()
+    row2 = body2["rows"][0]
+    assert row2.get("image_url", "").endswith("/aaaaaaa.jpg")
+    assert "video_url" not in row2
+    assert "video_duration_sec" not in row2
+
+
+def test_pipeline_hoists_image_url_video_url_to_top_level():
+    """/simulate/publish should hoist image_url / video_url out of the
+    payload exactly the same way it hoists image_cid / video_cid."""
+    from datetime import datetime, timezone, timedelta
+    from publisher.app.pipeline import MessageProcessor
+    from policy.engine import PolicyEngine
+    from policy.store import ConsentStore
+    from policy.models import ConsentVC
+    from audit.repository import SQLiteAuditRepository
+    import tempfile
+    import os
+
+    captured: list[dict] = []
+
+    class _Sink:
+        def send(self, env: dict) -> None:
+            captured.append(env)
+
+    with tempfile.TemporaryDirectory() as td:
+        cs = ConsentStore(os.path.join(td, "c.json"))
+        now = datetime.now(timezone.utc)
+        cs.upsert(
+            ConsentVC(
+                vc_id="c-stage-t-b",
+                subject_did="did:example:park",
+                dataset_id="home/event/possible_littering",
+                allowed_purposes=["community_cleaning"],
+                retention_days=14,
+                reshare_allowed=False,
+                valid_from=now - timedelta(days=1),
+                valid_to=now + timedelta(days=30),
+                signature="x",
+            )
+        )
+        proc = MessageProcessor(
+            publisher_id="t",
+            default_purpose="community_cleaning",
+            consent_store=cs,
+            policy_engine=PolicyEngine(),
+            audit_repo=SQLiteAuditRepository(os.path.join(td, "a.db")),
+            platform_client=_Sink(),
+        )
+        result = proc.process_message(
+            "homeassistant/event/possible_littering",
+            {
+                "event_type": "possible_littering",
+                "ts": "2026-04-29T09:00:00Z",
+                "source": "edge_inference",
+                "image_url": "http://publisher:8080/media/aaa.jpg",
+                "data": {
+                    "video_url": "http://publisher:8080/media/bbb.mp4",
+                    "video_duration_sec": 4,
+                },
+            },
+            "community_cleaning",
+        )
+        assert result["status"] == "allowed", result
+        assert captured
+        env = captured[-1]
+        assert env.get("image_url") == "http://publisher:8080/media/aaa.jpg"
+        assert env.get("video_url") == "http://publisher:8080/media/bbb.mp4"
+        assert env.get("video_duration_sec") == 4


### PR DESCRIPTION
## Summary

Carries the **actual image / video bytes** end-to-end alongside the existing tier-aware `allowed_views` projection — the receiver-side flow stays unchanged.

### Scope

The Stage T case alpha PR only filtered the **keys** (`image_cid` / `video_cid`) per tier. This PR adds a publisher-hosted HTTP media gateway so a data provider can stash the actual JPEG / MP4, get back a stable URL, and fold it into the event payload as `image_url` / `video_url`. The receiver dereferences the URL like any other static asset; the tier projection allows or blocks the URL key per tier.

### What's new

- `publisher/app/media_routes.py`
  - `POST /media/upload` — multipart blob → writes `<sha256>.<ext>` under `MEDIA_STORE_PATH`; dedupes on sha256. Returns `{url, sha256, content_type, byte_size}`.
  - `GET /media/{name}` — streams the blob with the right content-type, rejects traversal. Unauthenticated by design — the URL itself is the access control, and the real auth lives upstream at `/platform/data`.
- `/platform/data` tier projection now filters `image_url` / `video_url` alongside `image_cid` / `video_cid` (the two coexist, so a row can ship both during migration).
- `pipeline.py` hoists `image_url` / `video_url` to the envelope's top level the same way it already hoists `image_cid` / `video_cid`.
- `examples/hands_on/data_user_vc_tiered/provider_with_media.py` — one-shot script that generates a 1×1 JPEG / MP4 fixture, uploads both, and publishes a `possible_littering` event with the resulting URLs.
- `infra/docker-compose.yml` exposes `MEDIA_STORE_PATH=/data/media` (rides the existing `publisher_data` volume) and an optional `MEDIA_PUBLIC_BASE_URL` for deployments behind an alternate external URL.

### Tests

```
uv run pytest -q
# 100 passed (94 existing + 6 new)
```

The 6 new tests in `tests/test_data_user_vc_tiered.py`:
- `test_media_upload_then_serve` — round-trips a JPEG.
- `test_media_upload_dedupes_on_sha256` — same blob via two filenames returns the same URL.
- `test_media_upload_rejects_unknown_extension` — `.exe` → 415.
- `test_media_get_rejects_path_traversal` — `..%2F` → 400/404.
- `test_platform_data_projects_image_url_video_url_per_tier` — Tier 3 sees both URLs, Tier 2 sees only `image_url`.
- `test_pipeline_hoists_image_url_video_url_to_top_level` — pipeline-level test for the URL hoist.

### Compatibility

- Existing rows that ship only `image_cid` / `video_cid` keep working — tier projection treats `image_cid` and `image_url` symmetrically.
- Stage T case α + case B coexist in a single envelope.

### Test plan
- [ ] iPhone real-device: re-run the Stage T walkthrough with `provider_with_media.py` driving the producer side; tap the `image_url` in the wallet and confirm the JPEG opens.
- [ ] Confirm the receiver still passes the §7 tier-projection acceptance from the previous validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
