### PR TITLE
chore: ignore Stage T artefacts (fixtures, infra/.env, HA volume)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,14 @@ __pycache__/
 
 # Stage T (case B): default media gateway store dir
 publisher/data/
+
+# Stage T (case B) — provider_with_media.py auto-generates these
+# 1×1 fixture blobs at runtime; no need to track them.
+examples/hands_on/data_user_vc_tiered/fixtures/
+
+# Local-dev only — host IP / RPC URL are operator-specific.
+infra/.env
+
+# Home Assistant demo container's persistent volume; lives in the
+# repo only because docker-compose mounts it from the working tree.
+home-assistant-demo/


### PR DESCRIPTION
Tiny housekeeping PR: three untracked paths were piling up in `git status` after the Stage T case B real-device validation runs. None should be committed:
- `examples/hands_on/data_user_vc_tiered/fixtures/` — the 1×1 JPEG / MP4 fixtures that `provider_with_media.py` auto-generates.
- `infra/.env` — operator-specific LAN IP / Hardhat RPC.
- `home-assistant-demo/` — the HA container's persistent volume mounted from the worktree.

Just adds them to .gitignore so the working tree stays clean between Stage T sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)