### PR TITLE
feat(viewer): Stage T PWA viewer (same-device + cross-device)

### DIFF
--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -16,6 +16,7 @@ from publisher.app.mqtt_subscriber import MQTTSubscriber
 from publisher.app.pipeline import MessageProcessor
 from publisher.app.platform_client import PlatformClient
 from publisher.app.media_routes import build_router as build_media_router
+from publisher.app.viewer_routes import build_router as build_viewer_router
 from publisher.app.ssi import issuer_routes, verifier_routes
 from publisher.app.ssi.config import SSISettings
 from publisher.app.ssi.keys import IssuerKeyStore
@@ -111,6 +112,12 @@ app.include_router(
         ipfs_gateway_url=settings.ipfs_gateway_url,
     )
 )
+
+# Stage T (PWA viewer): /viewer + /buyer/start render the buyer-side
+# UX so neither phone nor PC needs to copy URLs by hand. Both pages
+# are plain HTML + small JS so they work uniformly on Safari, Chrome,
+# Edge, Firefox.
+app.include_router(build_viewer_router())
 
 
 @app.on_event("startup")

--- a/publisher/app/ssi/verifier_routes.py
+++ b/publisher/app/ssi/verifier_routes.py
@@ -392,6 +392,7 @@ def build_router(deps: VerifierDeps) -> APIRouter:
 
     @router.post("/verifier/response")
     def verifier_response(
+        request: Request,
         vp_token: str = Form(...),
         state: str = Form(...),
         # Only sent for PEX (presentation_definition) responses. DCQL responses
@@ -527,6 +528,35 @@ def build_router(deps: VerifierDeps) -> APIRouter:
                     for k in ("merchandise_address", "buyer_eth_addr", "tx_hash"):
                         if claims.get(k) is not None:
                             resp[k] = claims[k]
+
+                # Stage T (PWA viewer):
+                # 1. stash viewer_token onto VerificationRequest.result so
+                #    /verifier/status (long-poll) can return it for the
+                #    PC cross-device flow.
+                # 2. add an OID4VP `redirect_uri` so OS-level deeplink
+                #    handlers (Sphereon mobile-wallet) bounce the user
+                #    straight into the publisher's /viewer page after a
+                #    successful same-device presentation.
+                deps.state.record_verification_result(
+                    state,
+                    {
+                        "verified": True,
+                        "reason": reason,
+                        "viewer_token": vt.token,
+                        "viewer_token_jti": vt.jti,
+                        "expires_in": int(vt.expires_at - vt.issued_at),
+                        "allowed_views": list(vt.allowed_views),
+                        "dataset_id": req.dataset_id,
+                        "vc_kind": req.vc_kind,
+                    },
+                )
+                public_base = externally_reachable_base_url(
+                    request, deps.settings.issuer_base_url
+                )
+                resp["redirect_uri"] = (
+                    f"{public_base.rstrip('/')}/viewer"
+                    f"?vt={vt.token}&ds={urllib.parse.quote(req.dataset_id)}"
+                )
                 return resp
             if req.vc_kind == "SellerVC":
                 seller_st = deps.state.create_seller_token(
@@ -612,15 +642,41 @@ def build_router(deps: VerifierDeps) -> APIRouter:
         return {"status": "denied", "dataset_id": req.dataset_id, "reason": reason}
 
     @router.get("/verifier/status")
-    def verifier_status(state: str = Query(...)) -> dict:
+    def verifier_status(request: Request, state: str = Query(...)) -> dict:
+        """Verifier-state poll endpoint.
+
+        The PWA Buyer-Start page polls this every ~2 s while the user is
+        scanning a QR on a separate device. Once /verifier/response has
+        stashed a viewer_token onto the request's `result`, this echoes
+        it back along with a ready-to-redirect ``viewer_url`` so the
+        polling page can navigate to the data viewer.
+        """
         req = deps.state.find_verification_request(state)
         if not req:
             raise HTTPException(status_code=404, detail="unknown_or_expired_state")
-        return {
+
+        result = req.result or {}
+        out: dict = {
             "state": state,
-            "result": req.result,
+            "result": result,
             "dataset_id": req.dataset_id,
             "purpose": req.purpose,
+            "vc_kind": req.vc_kind,
         }
+        # When the verification has succeeded and minted a ViewerToken,
+        # surface a fully-formed `viewer_url` the polling page can redirect to.
+        if isinstance(result, dict) and result.get("verified") and result.get("viewer_token"):
+            public_base = externally_reachable_base_url(
+                request, deps.settings.issuer_base_url
+            )
+            out["viewer_token"] = result["viewer_token"]
+            out["allowed_views"] = result.get("allowed_views") or []
+            out["expires_in"] = result.get("expires_in")
+            out["viewer_url"] = (
+                f"{public_base.rstrip('/')}/viewer"
+                f"?vt={result['viewer_token']}"
+                f"&ds={urllib.parse.quote(req.dataset_id)}"
+            )
+        return out
 
     return router

--- a/publisher/app/viewer_routes.py
+++ b/publisher/app/viewer_routes.py
@@ -1,0 +1,402 @@
+"""Stage T (PWA viewer) — minimal browser UI for buyers.
+
+Two pages, both shippable as plain HTML + a few lines of JS so a wallet
+or PC browser can render data right after the OID4VP presentation
+succeeds:
+
+* ``GET /viewer?vt=<viewer_token>&ds=<dataset_id>``
+    Reads ``/platform/data`` with the viewer_token (Bearer) and renders
+    image / video / event JSON inline. Works on iPhone Safari and PC
+    Chrome / Edge / Firefox identically.
+
+* ``GET /buyer/start?ds=<dataset_id>``
+    Single page that adapts to device:
+
+    * **Mobile UA** -- auto-redirects to the OID4VP deeplink so the
+      iw3ip-wallet picks up the request, presents, and (thanks to the
+      ``redirect_uri`` we hand back at /verifier/response) lands the
+      buyer back on /viewer?vt=...
+    * **Desktop UA** -- renders a QR for the same deeplink and starts
+      polling /verifier/status?state=...; once the wallet on the user's
+      phone completes the presentation, the page navigates to the
+      ``viewer_url`` returned by /verifier/status.
+
+The whole thing is dependency-free server-side; we just emit HTML + JS.
+The QR rendering happens client-side via ``qrcode-svg`` (CDN-pinned)
+so the publisher doesn't have to install browser-side JS deps.
+"""
+from __future__ import annotations
+
+import html
+import json
+import logging
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/viewer", response_class=HTMLResponse)
+    def viewer_page(
+        request: Request,
+        vt: str = Query(..., description="ViewerToken"),
+        ds: str = Query(..., description="dataset_id"),
+    ) -> HTMLResponse:
+        """HTML viewer that reads /platform/data and renders the row."""
+        # Sanitise the values we splice into the page; we'll only echo
+        # them back as JSON literals (json.dumps is HTML-safe enough for
+        # data-* attributes here).
+        safe_vt = json.dumps(vt)
+        safe_ds = json.dumps(ds)
+        page_origin = str(request.base_url).rstrip("/")
+        safe_origin = json.dumps(page_origin)
+
+        body = _VIEWER_HTML.replace("__VT__", safe_vt) \
+                           .replace("__DS__", safe_ds) \
+                           .replace("__ORIGIN__", safe_origin)
+        return HTMLResponse(body)
+
+    @router.get("/buyer/start", response_class=HTMLResponse)
+    def buyer_start_page(
+        request: Request,
+        ds: str = Query(..., description="dataset_id"),
+        purpose: str = Query("read"),
+        vc_kind: str = Query("PurchaseViewerVC"),
+    ) -> HTMLResponse:
+        """Single page that bootstraps the OID4VP request + UA-aware UX."""
+        if not ds:
+            raise HTTPException(status_code=400, detail="ds_required")
+        # Build the same-device deeplink and give the page enough info
+        # to long-poll /verifier/status. We hand the actual /verifier/request
+        # call to the client-side script so the page mints a fresh
+        # state per page-load (avoiding stale sessions on hot-reload).
+        page_origin = str(request.base_url).rstrip("/")
+        safe = lambda v: json.dumps(v)  # noqa: E731
+        body = (
+            _BUYER_START_HTML
+            .replace("__ORIGIN__", safe(page_origin))
+            .replace("__DS__", safe(ds))
+            .replace("__PURPOSE__", safe(purpose))
+            .replace("__VC_KIND__", safe(vc_kind))
+        )
+        return HTMLResponse(body)
+
+    return router
+
+
+# ----------------------------------------------------------------------
+# /viewer page template
+# ----------------------------------------------------------------------
+_VIEWER_HTML = r"""<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>IW3IP Viewer</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      margin: 0;
+      padding: 1rem;
+      max-width: 760px;
+      margin-inline: auto;
+      line-height: 1.5;
+    }
+    header { display: flex; align-items: baseline; gap: 0.75rem; margin-bottom: 1rem; }
+    h1 { font-size: 1.25rem; margin: 0; }
+    .badge {
+      font-size: 0.75rem;
+      padding: 2px 8px;
+      border-radius: 999px;
+      background: rgba(33, 150, 243, 0.15);
+      color: #1565c0;
+    }
+    .badge.tier-3 { background: rgba(76, 175, 80, 0.18); color: #2e7d32; }
+    .badge.tier-2 { background: rgba(255, 152, 0, 0.20); color: #c77800; }
+    .badge.tier-1 { background: rgba(158, 158, 158, 0.25); color: #555; }
+    section { margin-block: 1rem; }
+    .media { display: grid; gap: 0.75rem; }
+    .media img, .media video {
+      width: 100%; max-height: 360px; object-fit: contain;
+      border-radius: 8px; background: #f3f3f3;
+    }
+    pre {
+      background: #1e1e1e; color: #eaeaea; padding: 0.75rem; border-radius: 6px;
+      overflow-x: auto; font-size: 0.78rem;
+    }
+    .empty { padding: 1rem; background: #fff7e6; border-radius: 6px; color: #8a6d3b; }
+    .err { padding: 1rem; background: #fdecea; border-radius: 6px; color: #b71c1c; }
+    .meta { font-size: 0.85rem; color: #666; }
+    a.cid {
+      font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+      word-break: break-all;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1 id="title">IW3IP Viewer</h1>
+    <span id="tier" class="badge">…</span>
+  </header>
+  <p class="meta" id="meta"></p>
+
+  <div id="root">
+    <p>Loading…</p>
+  </div>
+
+  <script>
+    const VT = __VT__;
+    const DS = __DS__;
+    const ORIGIN = __ORIGIN__;
+
+    function el(tag, attrs, ...children) {
+      const e = document.createElement(tag);
+      for (const [k, v] of Object.entries(attrs || {})) {
+        if (v == null) continue;
+        if (k === "class") e.className = v;
+        else if (k === "text") e.textContent = v;
+        else e.setAttribute(k, v);
+      }
+      for (const c of children) {
+        if (c == null) continue;
+        e.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+      }
+      return e;
+    }
+
+    async function load() {
+      const root = document.getElementById("root");
+      root.innerHTML = "";
+      try {
+        const r = await fetch(
+          `${ORIGIN}/platform/data?dataset_id=${encodeURIComponent(DS)}`,
+          { headers: { Authorization: `Bearer ${VT}` } }
+        );
+        if (!r.ok) {
+          const err = await r.text();
+          root.appendChild(el("div", { class: "err",
+            text: `HTTP ${r.status}: ${err.slice(0, 240)}` }));
+          if (r.status === 401) {
+            root.appendChild(el("p", {
+              text: "ViewerToken の TTL は 60 秒です。期限切れの場合は購入画面から再提示してください。"
+            }));
+          }
+          return;
+        }
+        const body = await r.json();
+        const tier = (body.allowed_views || []).join("+") || "—";
+        document.getElementById("tier").textContent = `tier: ${tier}`;
+        document.getElementById("tier").classList.add(
+          body.allowed_views?.includes("video") ? "tier-3" :
+          body.allowed_views?.includes("image") ? "tier-2" : "tier-1"
+        );
+        document.getElementById("meta").textContent =
+          `${DS} • ${body.count} row${body.count === 1 ? "" : "s"}` +
+          (body.seller_did ? ` • seller=${body.seller_did}` : "");
+
+        if (!body.rows?.length) {
+          root.appendChild(el("div", { class: "empty",
+            text: "このデータセットにはまだイベントが届いていません。" }));
+          return;
+        }
+        for (const row of body.rows) {
+          root.appendChild(renderRow(row));
+        }
+      } catch (e) {
+        root.innerHTML = "";
+        root.appendChild(el("div", { class: "err",
+          text: `network error: ${e.message || e}` }));
+      }
+    }
+
+    function renderRow(row) {
+      const card = el("section");
+      const media = el("div", { class: "media" });
+
+      // image_url is the publisher-hosted URL (Stage T case B). When
+      // the producer used IPFS too (case C) image_cid + ipfs_gateway_url
+      // also exist; we just prefer image_url for the inline render
+      // because it's guaranteed-reachable on the buyer's network.
+      if (row.image_url) {
+        media.appendChild(el("img", { src: row.image_url, alt: "image" }));
+      }
+      if (row.video_url) {
+        media.appendChild(el("video", { src: row.video_url, controls: "" }));
+      }
+      if (media.children.length) card.appendChild(media);
+
+      // Surface the IPFS CID if present so the viewer doubles as
+      // proof-of-content-addressing.
+      if (row.image_cid) {
+        card.appendChild(el("p", { class: "meta" },
+          "IPFS CID: ",
+          el("a", { class: "cid", href: `${ORIGIN}/ipfs/${row.image_cid}` },
+            row.image_cid)
+        ));
+      }
+
+      const ts = row.payload?.ts || row.ts || "";
+      if (ts) card.appendChild(el("p", { class: "meta", text: `ts: ${ts}` }));
+
+      const detail = el("details");
+      detail.appendChild(el("summary", { text: "Payload (raw)" }));
+      detail.appendChild(el("pre", { text: JSON.stringify(row, null, 2) }));
+      card.appendChild(detail);
+      return card;
+    }
+
+    load();
+  </script>
+</body>
+</html>
+"""
+
+
+# ----------------------------------------------------------------------
+# /buyer/start page template
+# ----------------------------------------------------------------------
+_BUYER_START_HTML = r"""<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>IW3IP Purchase</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      margin: 0; padding: 1rem; max-width: 720px; margin-inline: auto;
+      line-height: 1.5;
+    }
+    h1 { font-size: 1.2rem; margin-block-start: 0; }
+    .qr {
+      display: grid; place-items: center; padding: 1rem; background: #fff;
+      border: 1px solid #ddd; border-radius: 8px; margin-block: 1rem;
+    }
+    .qr svg { max-width: 100%; height: auto; }
+    .meta { font-size: 0.85rem; color: #666; }
+    .err { padding: 1rem; background: #fdecea; border-radius: 6px; color: #b71c1c; }
+    .deeplink {
+      display: inline-block; padding: 0.6rem 1rem;
+      background: #2196f3; color: #fff; border-radius: 6px;
+      text-decoration: none; margin-block: 0.5rem;
+    }
+    .pulse { animation: pulse 1.4s ease-in-out infinite; }
+    @keyframes pulse {
+      0%, 100% { opacity: 0.55; }
+      50% { opacity: 1; }
+    }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/qrcode-svg@1.1.0/dist/qrcode.min.js"></script>
+</head>
+<body>
+  <h1>IW3IP Purchase</h1>
+  <p class="meta" id="meta"></p>
+  <div id="root"><p class="pulse">Bootstrapping verifier session…</p></div>
+
+  <script>
+    const ORIGIN = __ORIGIN__;
+    const DS = __DS__;
+    const PURPOSE = __PURPOSE__;
+    const VC_KIND = __VC_KIND__;
+
+    const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+    document.getElementById("meta").textContent =
+      `dataset_id=${DS} • purpose=${PURPOSE} • ${isMobile ? "📱 same-device" : "🖥 cross-device"}`;
+
+    async function bootstrap() {
+      const root = document.getElementById("root");
+      try {
+        const url = new URL(`${ORIGIN}/verifier/request`);
+        url.searchParams.set("dataset_id", DS);
+        url.searchParams.set("purpose", PURPOSE);
+        url.searchParams.set("vc_kind", VC_KIND);
+        const r = await fetch(url, { headers: { Accept: "application/json" } });
+        if (!r.ok) {
+          root.innerHTML = "";
+          root.append(Object.assign(document.createElement("div"),
+            { className: "err", textContent: `HTTP ${r.status}: ${await r.text()}` }));
+          return;
+        }
+        const body = await r.json();
+        const deeplink = body.deeplink;
+        const state = body.authorization_request?.state;
+        if (!deeplink || !state) {
+          root.textContent = "Unexpected /verifier/request response";
+          return;
+        }
+        if (isMobile) {
+          // Same-device: jump straight to the wallet. The wallet will
+          // bounce back to /viewer via redirect_uri once it presents.
+          root.innerHTML = `
+            <p>📱 ウォレットを起動しています…</p>
+            <a class="deeplink" href="${deeplink}">ウォレットで開く</a>
+            <p class="meta">起動しない場合は上のボタンをタップしてください。</p>
+          `;
+          window.location.href = deeplink;
+        } else {
+          // Desktop: show QR + start polling for completion.
+          renderQrAndPoll(deeplink, state);
+        }
+      } catch (e) {
+        root.innerHTML = "";
+        root.append(Object.assign(document.createElement("div"),
+          { className: "err", textContent: `network error: ${e.message || e}` }));
+      }
+    }
+
+    function renderQrAndPoll(deeplink, state) {
+      const root = document.getElementById("root");
+      root.innerHTML = `
+        <p>🖥 PC からの購入は、<strong>iPhone のウォレットで下の QR を読み取る</strong>と進みます。</p>
+        <div class="qr" id="qr"></div>
+        <p class="pulse meta">ウォレットでの提示を待っています…（state=${state.slice(0, 10)}…）</p>
+        <details>
+          <summary>deeplink (debug)</summary>
+          <p style="word-break:break-all;font-family:ui-monospace,Menlo,monospace;font-size:0.78rem">${deeplink}</p>
+        </details>
+      `;
+      // QRCode is provided by qrcode-svg.
+      const qr = new QRCode({ content: deeplink, width: 280, height: 280, padding: 0 });
+      document.getElementById("qr").innerHTML = qr.svg();
+      pollUntilDone(state);
+    }
+
+    let lastShown = 0;
+    async function pollUntilDone(state) {
+      while (true) {
+        try {
+          const r = await fetch(
+            `${ORIGIN}/verifier/status?state=${encodeURIComponent(state)}`,
+            { headers: { Accept: "application/json" } }
+          );
+          if (r.ok) {
+            const body = await r.json();
+            if (body.viewer_url) {
+              window.location.href = body.viewer_url;
+              return;
+            }
+          } else if (r.status === 404) {
+            // session expired
+            const root = document.getElementById("root");
+            root.innerHTML = `<div class="err">verifier session expired. リロードしてやり直してください。</div>`;
+            return;
+          }
+        } catch (e) {
+          // transient error, keep polling
+        }
+        await new Promise(r => setTimeout(r, 2000));
+      }
+    }
+
+    bootstrap();
+  </script>
+</body>
+</html>
+"""

--- a/tests/test_data_user_vc_tiered.py
+++ b/tests/test_data_user_vc_tiered.py
@@ -1028,6 +1028,92 @@ def test_ipfs_proxy_502_when_gateway_unreachable(client_with_ipfs):
     assert "ipfs_gateway_unreachable" in r.json()["detail"]
 
 
+# ---- Stage T PWA viewer: /viewer + /buyer/start + redirect_uri ----
+
+
+def test_viewer_page_renders_html_with_token(client):
+    tc, _ = client
+    r = tc.get("/viewer", params={"vt": "fake-token", "ds": "home/env/temperature"})
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/html")
+    body = r.text
+    # Must contain the viewer_token + dataset_id so the page-side JS can
+    # fetch /platform/data without round-tripping back to the server.
+    assert "fake-token" in body
+    assert "home/env/temperature" in body
+    # Should pull image_url + image_cid into the rendering script.
+    assert "image_url" in body
+    assert "image_cid" in body
+
+
+def test_viewer_page_requires_query_params(client):
+    tc, _ = client
+    r = tc.get("/viewer", params={"vt": "fake-token"})  # no ds
+    assert r.status_code == 422
+    r = tc.get("/viewer", params={"ds": "home/env/temperature"})  # no vt
+    assert r.status_code == 422
+
+
+def test_buyer_start_page_renders_html(client):
+    tc, _ = client
+    r = tc.get("/buyer/start", params={"ds": "home/event/possible_littering"})
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/html")
+    body = r.text
+    # Page bootstraps /verifier/request itself; just check the page wires
+    # the right arguments and references /verifier/status for the poll.
+    assert "home/event/possible_littering" in body
+    assert "/verifier/request" in body
+    assert "/verifier/status" in body
+    # QR rendering is client-side via qrcode-svg CDN.
+    assert "qrcode" in body.lower() or "QRCode" in body
+
+
+def test_verifier_response_returns_redirect_uri_for_purchase_viewer(client):
+    """PR #29 + PWA viewer: a successful PurchaseViewerVC presentation
+    must echo a `redirect_uri` pointing at /viewer?vt=...&ds=... so the
+    OS-level wallet handoff can land the buyer on the data viewer."""
+    tc, _ = client
+    presented = _purchase_viewer_token(
+        tc, allowed_views_in_claim=["event", "image", "video"], tx_seed="a3"
+    )
+    assert presented["status"] == "allowed"
+    assert "redirect_uri" in presented, presented
+    assert presented["redirect_uri"].endswith(
+        f"/viewer?vt={presented['viewer_token']}&ds=home/env/temperature"
+    )
+
+
+def test_verifier_status_surfaces_viewer_url_after_success(client):
+    """The PC cross-device flow polls /verifier/status; once the wallet
+    has presented, the response must contain a ready-to-redirect
+    `viewer_url`."""
+    tc, _ = client
+    presented = _purchase_viewer_token(
+        tc, allowed_views_in_claim=["event", "image"], tx_seed="a4"
+    )
+    # Find the most recent verification request state by inspecting the
+    # publisher's in-memory store.
+    pm = __import__("publisher.app.main", fromlist=["app"])
+    states = list(pm.ssi_state._requests.keys())
+    # The most recent state is the one created by _purchase_viewer_token.
+    state = states[-1]
+    r = tc.get("/verifier/status", params={"state": state})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["viewer_token"] == presented["viewer_token"]
+    assert body["allowed_views"] == ["event", "image"]
+    assert body["viewer_url"].endswith(
+        f"/viewer?vt={presented['viewer_token']}&ds=home/env/temperature"
+    )
+
+
+def test_verifier_status_404_for_unknown_state(client):
+    tc, _ = client
+    r = tc.get("/verifier/status", params={"state": "nope-no-such-state"})
+    assert r.status_code == 404
+
+
 def test_provider_payload_carries_cid_when_ipfs_active(client_with_ipfs):
     """End-to-end: when IPFS is on, the upload response carries a CID,
     and a payload that folds it in surfaces image_cid at /platform/data


### PR DESCRIPTION
## Summary

Drops the "copy `/platform/data` URL into Safari by hand" step from the Stage T hands-on. After this PR, buyers land on a real HTML viewer right after the OID4VP presentation succeeds — on **iPhone Safari _and_ PC Chrome / Edge / Firefox**, with no app install on the desktop side.

### Two pages, one publisher

- **`GET /viewer?vt=<viewer_token>&ds=<dataset_id>`**
  - Plain HTML + ~80 lines of JS.
  - Reads `/platform/data` with the `viewer_token`, renders `image_url` / `video_url` inline as `<img>` / `<video>`.
  - Surfaces `image_cid` as a clickable link to the publisher's `/ipfs/<cid>` proxy (Stage T case C).
  - Tier badge shows `event` / `event+image` / `event+image+video` so the buyer knows which projection they paid for.

- **`GET /buyer/start?ds=<dataset_id>&purpose=&vc_kind=`**
  - One page, two device modes:
    - **Mobile UA** — `window.location = deeplink` to launch the wallet; the wallet's `redirect_uri` (this PR adds it) bounces back to `/viewer` after presentation.
    - **Desktop UA** — renders a QR (browser-side `qrcode-svg` from a CDN; no JS bundle on the publisher) and long-polls `/verifier/status?state=...`. Once the wallet on the buyer's phone presents, the desktop page redirects to `viewer_url`.

### Verifier wiring

- `/verifier/response` now stashes `viewer_token` + `dataset_id` + `allowed_views` onto `VerificationRequest.result` and the successful PurchaseViewerVC / ViewerVC response now carries `redirect_uri = "<public_base>/viewer?vt=...&ds=..."` (OID4VP standard field).
- `/verifier/status` long-poll endpoint now returns `viewer_token` + `viewer_url` alongside the existing `result` so the desktop page can navigate without re-decoding the VC.

### UX flow diagram

```
[iPhone Safari]                 [iw3ip-wallet]              [publisher]
   |                                  |                          |
   | GET /buyer/start?ds=...          |                          |
   |--------------------------------->|                          |
   |                                  |    /verifier/request     |
   |  redirect to deeplink            |<-------------------------|
   |--------------------------------->|                          |
   |                                  | OID4VP present           |
   |                                  |------------------------->|
   |                                  |  redirect_uri=/viewer    |
   |                                  |<-------------------------|
   |  (Safari opens /viewer?vt=...)                              |
   |<------------------------------------------------------------|
   |                                                             |
   | GET /platform/data (Bearer)                                 |
   |------------------------------------------------------------>|
   | <img src=image_url> 自動描画                                 |

[PC Chrome]                     [iPhone iw3ip-wallet]            [publisher]
   |                                  |                                |
   | GET /buyer/start?ds=...          |                                |
   |--------------------------------->|                                |
   |  HTML: QR + 「ウォレットで承認」 |                                  |
   |<---------------------------------|                                |
   |                                                                   |
   |                            [QR scan] -> deeplink                  |
   |                                  |                                |
   |                                  | OID4VP present                 |
   |                                  |------------------------------->|
   |                                                                   | mint ViewerToken
   | (long-poll) /verifier/status                                      |
   |------------------------------------------------------------------>|
   | { viewer_url: "/viewer?vt=..." }                                  |
   |<------------------------------------------------------------------|
   | window.location = viewer_url                                      |
   | GET /viewer + /platform/data 自動描画                              |
```

### Tests

```
uv run pytest -q
# 112 passed (106 + 6 new)
```

The 6 new tests:
- `test_viewer_page_renders_html_with_token`
- `test_viewer_page_requires_query_params`
- `test_buyer_start_page_renders_html`
- `test_verifier_response_returns_redirect_uri_for_purchase_viewer`
- `test_verifier_status_surfaces_viewer_url_after_success`
- `test_verifier_status_404_for_unknown_state`

### Backward compatibility

- `/verifier/response` keeps every existing field; `redirect_uri` is purely additive.
- `/verifier/status` keeps `result` unchanged; only adds new top-level fields (`viewer_token`, `viewer_url`, `allowed_views`, `expires_in`) when the verification has minted a ViewerToken.
- The two new pages are pure-additive; no existing route changed.

### Test plan
- [ ] iPhone real-device: open `/buyer/start?ds=home/event/possible_littering` in Safari → wallet auto-launches → present Tier 3 → `/viewer` opens with image visible.
- [ ] PC real-device: same URL on Chrome → QR rendered → scan with iPhone → present → desktop page auto-navigates to `/viewer`.
- [ ] Confirm the existing Stage T case B / case C real-device walkthrough (tap `image_url`) still works without `/buyer/start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
