### PR TITLE
fix(ssi): Stage T - public-base client_id + human-readable deny errors

### DIFF
--- a/publisher/app/ssi/verifier_routes.py
+++ b/publisher/app/ssi/verifier_routes.py
@@ -42,6 +42,65 @@ def _vc_hash(vp_token: str) -> str:
     return "sha256:" + hashlib.sha256(compact.encode("utf-8")).hexdigest()
 
 
+# Stage T (PWA viewer): map verifier `reason` codes to human-readable
+# messages so /buyer/start, /viewer and the wallet can surface what
+# actually went wrong. Keep the JA strings short enough to render on a
+# phone in one or two lines; English mirrors the same idea.
+_DENY_HUMAN_MESSAGES: dict[str, dict[str, str]] = {
+    "dataset_mismatch": {
+        "ja": "提示された VC のデータセットが、要求されたデータセットと一致しません。",
+        "en": "The presented VC is bound to a different dataset.",
+    },
+    "action_not_allowed": {
+        "ja": "提示された VC では、このデータの読み取り権限がありません。",
+        "en": "The presented VC does not include the required action (read).",
+    },
+    "purpose_mismatch": {
+        "ja": "提示された VC の許可目的に、今回の用途が含まれていません。",
+        "en": "The presented VC's allowed_purposes does not cover this purpose.",
+    },
+    "missing_seller_id": {
+        "ja": "SellerVC に seller_id が含まれていません。",
+        "en": "SellerVC is missing seller_id.",
+    },
+    "missing_licensed_datasets": {
+        "ja": "SellerVC に出品許可データセットが含まれていません。",
+        "en": "SellerVC is missing licensed_datasets.",
+    },
+    "missing_entityType": {
+        "ja": "DataUserVC に entityType が含まれていません。",
+        "en": "DataUserVC is missing entityType.",
+    },
+    "missing_purpose": {
+        "ja": "DataUserVC に purpose が含まれていません。",
+        "en": "DataUserVC is missing purpose.",
+    },
+    "missing_dataHandlingPolicy": {
+        "ja": "DataUserVC に dataHandlingPolicy が含まれていません。",
+        "en": "DataUserVC is missing dataHandlingPolicy.",
+    },
+    "verification_failed": {
+        "ja": "VC の署名検証に失敗しました。",
+        "en": "VC verification failed.",
+    },
+}
+
+
+def _humanize_reason(reason: str) -> dict[str, str]:
+    """Turn a verifier-internal reason code into a JA/EN message pair.
+    Falls back to the raw code when we don't have a curated string yet
+    -- callers can still display it; the codes are user-readable enough
+    to be useful as a fallback."""
+    msg = _DENY_HUMAN_MESSAGES.get(reason)
+    if msg:
+        return {"reason": reason, "human_message_ja": msg["ja"], "human_message_en": msg["en"]}
+    return {
+        "reason": reason,
+        "human_message_ja": f"提示が拒否されました ({reason})。",
+        "human_message_en": f"Presentation denied ({reason}).",
+    }
+
+
 def _extract_sd_jwt_compact(raw_vp_token: str) -> str:
     """Pull the SD-JWT VC compact string out of whatever shape `vp_token` arrives in.
 
@@ -222,10 +281,17 @@ def build_router(deps: VerifierDeps) -> APIRouter:
         req = deps.state.create_verification_request(pd_id, dataset_id, purpose, vc_kind=vc_kind)
 
         public_base = externally_reachable_base_url(request, deps.settings.issuer_base_url)
+        # Stage T (PWA viewer + cross-device fix): client_id MUST match a
+        # URL the wallet can actually reach. The Docker-internal
+        # `issuer_base_url` (e.g. http://publisher:8080) trips up
+        # Sphereon mobile-wallet during cross-device flow because the
+        # wallet attempts to fetch client_metadata from the URL and
+        # times out -- the user then sees a generic "Network request
+        # failed". Use the externally-reachable base everywhere.
         authz = {
             "response_type": "vp_token",
             "response_mode": "direct_post",
-            "client_id": deps.settings.issuer_base_url,
+            "client_id": public_base,
             "response_uri": f"{public_base}/verifier/response",
             "presentation_definition": pd,
             "nonce": req.nonce,
@@ -372,15 +438,17 @@ def build_router(deps: VerifierDeps) -> APIRouter:
                 ]
             }
         public_base = externally_reachable_base_url(request, deps.settings.issuer_base_url)
+        # See note above /verifier/request — client_id + iss must match
+        # the URL the wallet can reach, not the Docker-internal one.
         payload = {
             "response_type": "vp_token",
             "response_mode": "direct_post",
-            "client_id": deps.settings.issuer_base_url,
+            "client_id": public_base,
             "response_uri": f"{public_base}/verifier/response",
             "dcql_query": dcql,
             "nonce": req.nonce,
             "state": req.state,
-            "iss": deps.settings.issuer_base_url,
+            "iss": public_base,
             "aud": "https://self-issued.me/v2",
         }
         h_b64 = _b64u(_json_bytes(header))
@@ -639,7 +707,28 @@ def build_router(deps: VerifierDeps) -> APIRouter:
                 "policy_token_jti": pt.jti,
                 "expires_in": int(pt.expires_at - pt.issued_at),
             }
-        return {"status": "denied", "dataset_id": req.dataset_id, "reason": reason}
+        # Stage T (PWA viewer): record the deny on the verification
+        # request so /verifier/status can echo a human-readable message
+        # back to the long-polling /buyer/start page.
+        deny_human = _humanize_reason(reason)
+        deps.state.record_verification_result(
+            state,
+            {
+                "verified": False,
+                "reason": reason,
+                "human_message_ja": deny_human["human_message_ja"],
+                "human_message_en": deny_human["human_message_en"],
+                "dataset_id": req.dataset_id,
+                "vc_kind": req.vc_kind,
+            },
+        )
+        return {
+            "status": "denied",
+            "dataset_id": req.dataset_id,
+            "reason": reason,
+            "human_message_ja": deny_human["human_message_ja"],
+            "human_message_en": deny_human["human_message_en"],
+        }
 
     @router.get("/verifier/status")
     def verifier_status(request: Request, state: str = Query(...)) -> dict:

--- a/publisher/app/viewer_routes.py
+++ b/publisher/app/viewer_routes.py
@@ -179,14 +179,23 @@ _VIEWER_HTML = r"""<!DOCTYPE html>
           { headers: { Authorization: `Bearer ${VT}` } }
         );
         if (!r.ok) {
-          const err = await r.text();
-          root.appendChild(el("div", { class: "err",
-            text: `HTTP ${r.status}: ${err.slice(0, 240)}` }));
+          let detail = "";
+          try { detail = JSON.stringify(await r.json()); }
+          catch { detail = await r.text(); }
+          const banner = el("div", { class: "err" });
           if (r.status === 401) {
-            root.appendChild(el("p", {
-              text: "ViewerToken の TTL は 60 秒です。期限切れの場合は購入画面から再提示してください。"
-            }));
+            banner.innerHTML = `<strong>ViewerToken の有効期限が切れています</strong><br />` +
+              `読み取り権限を再取得するため、購入画面 (<a href="${ORIGIN}/buyer/start?ds=${encodeURIComponent(DS)}">/buyer/start</a>) からウォレットで再提示してください。`;
+          } else if (r.status === 403) {
+            banner.innerHTML = `<strong>このデータを閲覧する権限がありません</strong><br />` +
+              `提示された VC ではこのデータセットへのアクセスが許可されていません。`;
+          } else if (r.status === 404) {
+            banner.innerHTML = `<strong>データセットが見つかりません</strong><br />` +
+              `dataset_id=${DS} は publisher に登録されていない可能性があります。`;
+          } else {
+            banner.textContent = `HTTP ${r.status}: ${detail.slice(0, 240)}`;
           }
+          root.appendChild(banner);
           return;
         }
         const body = await r.json();
@@ -378,12 +387,35 @@ _BUYER_START_HTML = r"""<!DOCTYPE html>
           );
           if (r.ok) {
             const body = await r.json();
+            // Success: navigate to the data viewer.
             if (body.viewer_url) {
               window.location.href = body.viewer_url;
               return;
             }
+            // Stage T (PWA viewer): the verifier denied the
+            // presentation. Show the human-readable reason instead of
+            // looping forever.
+            const result = body.result;
+            if (result && result.verified === false) {
+              const root = document.getElementById("root");
+              const msg = result.human_message_ja
+                       || result.human_message_en
+                       || `Presentation denied (${result.reason || "unknown"}).`;
+              root.innerHTML = `
+                <div class="err">
+                  <strong>データを閲覧する権限がありません</strong><br />
+                  ${msg}
+                </div>
+                <p class="meta">
+                  reason code: <code>${result.reason || ""}</code>
+                </p>
+                <p>
+                  別の VC で試す場合は<a href="" onclick="location.reload();return false;">このページをリロード</a>してください。
+                </p>
+              `;
+              return;
+            }
           } else if (r.status === 404) {
-            // session expired
             const root = document.getElementById("root");
             root.innerHTML = `<div class="err">verifier session expired. リロードしてやり直してください。</div>`;
             return;

--- a/tests/test_data_user_vc_tiered.py
+++ b/tests/test_data_user_vc_tiered.py
@@ -1114,6 +1114,128 @@ def test_verifier_status_404_for_unknown_state(client):
     assert r.status_code == 404
 
 
+def test_verifier_request_uses_public_base_for_client_id(client):
+    """Cross-device fix: client_id MUST be the publicly reachable base
+    URL, not the Docker-internal one. Sphereon mobile-wallet trips up
+    on internal hostnames during cross-device flow."""
+    tc, _ = client
+    # Use an explicit Host header to mimic what a wallet on the LAN
+    # would see; the publisher should echo *that* URL back as client_id.
+    r = tc.get(
+        "/verifier/request",
+        params={
+            "vc_kind": "PurchaseViewerVC",
+            "purpose": "read",
+            "dataset_id": "home/env/temperature",
+        },
+        headers={
+            "accept": "application/json",
+            "host": "192.168.68.53:8080",
+            "x-forwarded-proto": "http",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    authz = body["authorization_request"]
+    assert authz["client_id"].startswith("http://"), authz["client_id"]
+    # client_id and response_uri should agree on the host part.
+    assert authz["client_id"] in authz["response_uri"]
+    # Critically: the Docker-internal "publisher" hostname must NOT
+    # leak into client_id (that's what the cross-device flow trips on).
+    assert "publisher:8080" not in authz["client_id"], authz["client_id"]
+
+
+def test_verifier_response_deny_includes_human_message(client):
+    """Stage T (PWA viewer): when /verifier/response denies a VC, the
+    response body must include human_message_ja/en so the buyer knows
+    what went wrong instead of seeing a generic 'Network request
+    failed' from the wallet."""
+    tc, _ = client
+    # Build a verification request bound to home/env/temperature, then
+    # present a VC bound to a DIFFERENT dataset so the post-PEX check
+    # hits the dataset_mismatch path.
+    req = tc.get(
+        "/verifier/request",
+        params={"dataset_id": "home/env/temperature", "vc_kind": "ViewerVC"},
+        headers={"accept": "application/json"},
+    ).json()
+    state = req["authorization_request"]["state"]
+
+    # Issue a ViewerVC for home/env/temperature, then present it as if
+    # for the (also-temperature) verifier request -- but we'll patch
+    # the post-PEX claims to cause a synthetic dataset_mismatch.
+    priv, pub, _ = _holder()
+    offer = tc.get(
+        "/issuer/offer",
+        params={"type": "ViewerVC", "dataset_id": "home/env/temperature", "purpose": "read"},
+        headers={"accept": "application/json"},
+    ).json()
+    token = tc.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": offer["pre_authorized_code"],
+        },
+    ).json()
+    proof = _proof(priv, pub, token["c_nonce"], "http://testserver")
+    cred = tc.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+        json={
+            "format": "vc+sd-jwt",
+            "vct": "https://iw3ip.example/credentials/ViewerVC/v1",
+            "proof": {"proof_type": "jwt", "jwt": proof},
+        },
+    ).json()
+
+    # Patch the local-PEX fallback to claim the VC was for a different
+    # dataset than the verifier requested -> deny path with reason
+    # "dataset_mismatch".
+    from unittest.mock import patch as _patch
+    with _patch(
+        "publisher.app.ssi.verifier_routes._safe_local_pex_fallback",
+        return_value={
+            "verified": True,
+            "claims": {
+                "dataset_id": "home/event/something_else",
+                "allowed_actions": ["read"],
+                "subject_id": "did:jwk:abc",
+            },
+            "holder_did": "did:jwk:abc",
+            "reason": "ok",
+        },
+    ):
+        sub = {
+            "id": "sub-viewer-temperature",
+            "definition_id": "viewer-temperature",
+            "descriptor_map": [
+                {"id": "viewer_vc_temperature", "format": "vc+sd-jwt", "path": "$"}
+            ],
+        }
+        r = tc.post(
+            "/verifier/response",
+            data={
+                "vp_token": cred["credential"],
+                "presentation_submission": json.dumps(sub),
+                "state": state,
+            },
+        )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "denied"
+    assert body["reason"] == "dataset_mismatch"
+    # Must surface a JA + EN human-readable line.
+    assert "human_message_ja" in body and "human_message_en" in body
+    assert "データセット" in body["human_message_ja"]
+    # /verifier/status should also echo the deny details for the
+    # cross-device polling page to render.
+    status = tc.get("/verifier/status", params={"state": state}).json()
+    assert status["result"]["verified"] is False
+    assert status["result"]["reason"] == "dataset_mismatch"
+    assert "human_message_ja" in status["result"]
+
+
 def test_provider_payload_carries_cid_when_ipfs_active(client_with_ipfs):
     """End-to-end: when IPFS is on, the upload response carries a CID,
     and a payload that folds it in surfaces image_cid at /platform/data


### PR DESCRIPTION
## Summary

Fixes two real-device pain points that surfaced together during Stage T PWA validation: a cross-device presentation died with a generic "Network request failed" inside iw3ip-wallet, and the Stage T flow had no human-readable error path when a presentation was denied.

### Root cause #1 — Docker-internal `client_id` leaks to wallet

`/verifier/request` + `/verifier/request_object` pinned `client_id` and `iss` to `settings.issuer_base_url`, which in compose is the **Docker-internal** `http://publisher:8080`. Same-device flow (Tier 3 ✅) was getting away with it because Sphereon mobile-wallet skips client_metadata resolution on that path. Cross-device (Tier 2 ❌) tries to fetch client_metadata from `client_id`, the request times out, and the wallet aborts with a misleading "Network request failed".

**Fix:** use `externally_reachable_base_url(request, ...)` for both `client_id` and `iss` — mirroring how `response_uri` / `request_uri` / `redirect_uri` were already minted.

### Root cause #2 — deny codes never reached the user

Whenever the verifier denied a presentation (`dataset_mismatch`, `action_not_allowed`, `missing_*`...), the response only carried a short reason code. There was no Japanese / English string for the wallet, the `/buyer/start` long-poll page, or `/viewer` to render. Users saw only `Network request failed`.

**Fix:**
- `_humanize_reason()` with a JA/EN message table for every deny code.
- `/verifier/response` now returns `{ status, reason, human_message_ja, human_message_en, ... }` on deny and stashes the same fields onto `VerificationRequest.result`.
- `/verifier/status` echoes the deny details so `/buyer/start` can render a "データを閲覧する権限がありません" banner with the human message + reason code (instead of polling forever).
- `/viewer` 401 / 403 / 404 from `/platform/data` get JA banners pointing back at `/buyer/start` for re-presentation.

### Tests

```
uv run pytest -q
# 114 passed (112 + 2 new)
```

- `test_verifier_request_uses_public_base_for_client_id` — guards root cause #1; asserts `publisher:8080` never leaks into `client_id` and that `client_id` agrees with `response_uri`.
- `test_verifier_response_deny_includes_human_message` — drives the `dataset_mismatch` deny path and checks both the direct response and `/verifier/status` carry `human_message_ja/en`.

### Test plan
- [ ] iPhone same-device retry: Tier 3 still works, Tier 2 + Tier 1 too.
- [ ] PC cross-device retry: Tier 3 / 2 / 1 all complete (Tier 2 is the one #1 was blocking).
- [ ] PC cross-device negative test: present a VC for the wrong dataset → `/buyer/start` page replaces the QR with a "データを閲覧する権限がありません: 提示された VC のデータセットが、要求されたデータセットと一致しません。" banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
