### PR TITLE
chore(ssi): bump offer_ttl_seconds 600 -> 1800 (10min -> 30min)

### DIFF
--- a/publisher/app/ssi/config.py
+++ b/publisher/app/ssi/config.py
@@ -11,7 +11,7 @@ class SSISettings(BaseSettings):
     issuer_key_path: str = "/data/issuer_key.jwk.json"
     issuer_id: str = "iw3ip-publisher-issuer"
     credential_ttl_days: int = 365
-    offer_ttl_seconds: int = 600
+    offer_ttl_seconds: int = 1800
     pex_sidecar_url: str = "http://verifier-sidecar:7000"
     presentation_defs_dir: str = "/app/examples/ssi_wallet"
     response_ttl_seconds: int = 600


### PR DESCRIPTION
## Summary
- Stage T hands-on workshops typically run longer than the previous 10-minute offer window
- Bumps `offer_ttl_seconds` default from 600 to 1800 so a single offer covers a full hands-on slot end-to-end with margin for retries
- `SSI_OFFER_TTL_SECONDS` env override is unchanged

## Why
With the demo running over LAN to a phone, the QR-scan → wallet-switch → card-pick → present round-trip frequently crossed the 600s budget and the offer expired before the wallet posted `/openid4vci/token`, surfacing as a confusing 400 in the publisher logs.

## Test plan
- [ ] Hand out an offer, wait >10 minutes, present from wallet — no longer 400
- [ ] Existing tests still pass (no test asserts on the 600 default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)