### PR TITLE
feat(provider): Stage T (c1) — /provider/start + SellerToken via OID4VP

### DIFF
--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -17,6 +17,7 @@ from publisher.app.pipeline import MessageProcessor
 from publisher.app.platform_client import PlatformClient
 from publisher.app.media_routes import build_router as build_media_router
 from publisher.app.viewer_routes import build_router as build_viewer_router
+from publisher.app.provider_routes import build_router as build_provider_router
 from publisher.app.ssi import issuer_routes, verifier_routes
 from publisher.app.ssi.config import SSISettings
 from publisher.app.ssi.keys import IssuerKeyStore
@@ -118,6 +119,11 @@ app.include_router(
 # are plain HTML + small JS so they work uniformly on Safari, Chrome,
 # Edge, Firefox.
 app.include_router(build_viewer_router())
+
+# Stage T (PWA provider, c1): /provider/start renders the provider-side
+# OID4VP loop (SellerVC presentation -> SellerToken). The actual
+# upload + publish UI lands in c2.
+app.include_router(build_provider_router())
 
 
 @app.on_event("startup")

--- a/publisher/app/provider_routes.py
+++ b/publisher/app/provider_routes.py
@@ -1,0 +1,276 @@
+"""Stage T (PWA provider, c1) -- minimal browser UI for data providers.
+
+Mirror of /buyer/start but for SellerVC presentation. The page bootstraps
+a /verifier/request?vc_kind=SellerVC, shows a QR for cross-device flow
+(or jumps to the wallet for same-device), and on success renders an
+inline panel showing the SellerToken + licensed_datasets.
+
+The actual upload + /simulate/publish UI ships in c2; for c1 the page
+only proves that the OID4VP plumbing for the provider side works
+end-to-end (QR -> wallet -> SellerVC presentation -> SellerToken issued
+and surfaced back to the page).
+
+Same-device flow uses redirect_uri=/provider/start?state=... which the
+client-side script picks up to skip the bootstrap step and just resume
+polling.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/provider/start", response_class=HTMLResponse)
+    def provider_start_page(
+        request: Request,
+        ds: str | None = Query(
+            default=None,
+            description=(
+                "Optional dataset hint -- shown in the page header so the "
+                "provider knows which dataset they're about to publish to. "
+                "SellerVC verification itself is not dataset-bound; the "
+                "licensed_datasets check happens server-side at upload time."
+            ),
+        ),
+        state: str | None = Query(
+            default=None,
+            description=(
+                "Existing verifier state to resume polling against. Set by "
+                "the wallet's redirect_uri after a same-device presentation "
+                "so the page skips the bootstrap step."
+            ),
+        ),
+    ) -> HTMLResponse:
+        page_origin = str(request.base_url).rstrip("/")
+        safe = lambda v: json.dumps(v if v is not None else "")  # noqa: E731
+        body = (
+            _PROVIDER_START_HTML
+            .replace("__ORIGIN__", safe(page_origin))
+            .replace("__DS__", safe(ds))
+            .replace("__RESUME_STATE__", safe(state))
+        )
+        return HTMLResponse(body)
+
+    return router
+
+
+# ----------------------------------------------------------------------
+# /provider/start page template
+# ----------------------------------------------------------------------
+_PROVIDER_START_HTML = r"""<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>IW3IP Provider</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      margin: 0; padding: 1rem; max-width: 720px; margin-inline: auto;
+      line-height: 1.5;
+    }
+    h1 { font-size: 1.2rem; margin-block-start: 0; }
+    .qr {
+      display: grid; place-items: center; padding: 1rem; background: #fff;
+      border: 1px solid #ddd; border-radius: 8px; margin-block: 1rem;
+    }
+    .qr svg { max-width: 100%; height: auto; }
+    .meta { font-size: 0.85rem; color: #666; }
+    .err { padding: 1rem; background: #fdecea; border-radius: 6px; color: #b71c1c; }
+    .ok  { padding: 1rem; background: #e8f5e9; border-radius: 6px; color: #1b5e20; }
+    .deeplink {
+      display: inline-block; padding: 0.6rem 1rem;
+      background: #2e7d32; color: #fff; border-radius: 6px;
+      text-decoration: none; margin-block: 0.5rem;
+    }
+    .pulse { animation: pulse 1.4s ease-in-out infinite; }
+    @keyframes pulse {
+      0%, 100% { opacity: 0.55; }
+      50% { opacity: 1; }
+    }
+    code, .mono {
+      font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+      font-size: 0.85rem; word-break: break-all;
+    }
+    ul.licensed { padding-inline-start: 1.2rem; }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/qrcode-svg@1.1.0/dist/qrcode.min.js"></script>
+</head>
+<body>
+  <h1>IW3IP Provider</h1>
+  <p class="meta" id="meta"></p>
+  <div id="root"><p class="pulse">Bootstrapping verifier session…</p></div>
+
+  <script>
+    const ORIGIN = __ORIGIN__;
+    const DS_HINT = __DS__;
+    const RESUME_STATE = __RESUME_STATE__;
+    const VC_KIND = "SellerVC";
+
+    const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+    document.getElementById("meta").textContent =
+      (DS_HINT ? `dataset_hint=${DS_HINT} • ` : "")
+      + `vc_kind=${VC_KIND} • ${isMobile ? "📱 same-device" : "🖥 cross-device"}`;
+
+    async function bootstrap() {
+      const root = document.getElementById("root");
+
+      // Same-device return path: the wallet's redirect_uri brought us
+      // back with ?state=... already set. Skip /verifier/request and
+      // resume polling immediately.
+      if (RESUME_STATE) {
+        root.innerHTML = `<p class="pulse">ウォレットからの戻りを処理中…</p>`;
+        pollUntilDone(RESUME_STATE);
+        return;
+      }
+
+      try {
+        const url = new URL(`${ORIGIN}/verifier/request`);
+        url.searchParams.set("vc_kind", VC_KIND);
+        // SellerVC isn't dataset-scoped at verify time; verifier_routes
+        // accepts "*" as a sentinel. Pass the hint along anyway so audit
+        // logs see what the provider intended.
+        url.searchParams.set("dataset_id", DS_HINT || "*");
+        url.searchParams.set("purpose", "publish");
+        const r = await fetch(url, { headers: { Accept: "application/json" } });
+        if (!r.ok) {
+          root.innerHTML = "";
+          root.append(Object.assign(document.createElement("div"),
+            { className: "err", textContent: `HTTP ${r.status}: ${await r.text()}` }));
+          return;
+        }
+        const body = await r.json();
+        const deeplink = body.deeplink;
+        const state = body.authorization_request?.state;
+        if (!deeplink || !state) {
+          root.textContent = "Unexpected /verifier/request response";
+          return;
+        }
+        if (isMobile) {
+          // Same-device: jump to the wallet. Wallet's redirect_uri
+          // returns the user to /provider/start?state=... which the
+          // RESUME_STATE branch above picks up.
+          root.innerHTML = `
+            <p>📱 ウォレットを起動しています…</p>
+            <a class="deeplink" href="${deeplink}">ウォレットで開く</a>
+            <p class="meta">起動しない場合は上のボタンをタップしてください。</p>
+          `;
+          window.location.href = deeplink;
+        } else {
+          renderQrAndPoll(deeplink, state);
+        }
+      } catch (e) {
+        root.innerHTML = "";
+        root.append(Object.assign(document.createElement("div"),
+          { className: "err", textContent: `network error: ${e.message || e}` }));
+      }
+    }
+
+    function renderQrAndPoll(deeplink, state) {
+      const root = document.getElementById("root");
+      root.innerHTML = `
+        <p>🖥 PC からのデータ提供は、<strong>iPhone のウォレットで下の QR を読み取り SellerVC を提示</strong>すると進みます。</p>
+        <div class="qr" id="qr"></div>
+        <p class="pulse meta">ウォレットでの提示を待っています…（state=${state.slice(0, 10)}…）</p>
+        <details>
+          <summary>deeplink (debug)</summary>
+          <p class="mono">${deeplink}</p>
+        </details>
+      `;
+      const qr = new QRCode({ content: deeplink, width: 280, height: 280, padding: 0 });
+      document.getElementById("qr").innerHTML = qr.svg();
+      pollUntilDone(state);
+    }
+
+    async function pollUntilDone(state) {
+      while (true) {
+        try {
+          const r = await fetch(
+            `${ORIGIN}/verifier/status?state=${encodeURIComponent(state)}`,
+            { headers: { Accept: "application/json" } }
+          );
+          if (r.ok) {
+            const body = await r.json();
+            // Success: SellerToken minted. /verifier/status surfaces
+            // seller_token + licensed_datasets directly.
+            if (body.seller_token) {
+              renderSuccess(body);
+              return;
+            }
+            const result = body.result;
+            if (result && result.verified === false) {
+              renderDeny(result);
+              return;
+            }
+          } else if (r.status === 404) {
+            const root = document.getElementById("root");
+            root.innerHTML = `<div class="err">verifier session expired. リロードしてやり直してください。</div>`;
+            return;
+          }
+        } catch (e) {
+          // transient error, keep polling
+        }
+        await new Promise(r => setTimeout(r, 2000));
+      }
+    }
+
+    function renderSuccess(body) {
+      const root = document.getElementById("root");
+      const licensed = body.licensed_datasets || [];
+      const items = licensed.map(d => `<li><code>${d}</code></li>`).join("") || "<li><em>(none)</em></li>";
+      const expIn = body.expires_in ? `${Math.round(body.expires_in / 60)} 分` : "—";
+      root.innerHTML = `
+        <div class="ok">
+          <strong>SellerVC 提示が承認されました</strong><br />
+          ProviderToken (= SellerToken) を発行しました。
+        </div>
+        <h2 style="font-size:1rem;margin-top:1.5rem">出品許可データセット</h2>
+        <ul class="licensed">${items}</ul>
+        <p class="meta">seller_id: <code>${body.seller_id || "—"}</code></p>
+        <p class="meta">有効期限: ${expIn}</p>
+        <details style="margin-top:1rem">
+          <summary>SellerToken (debug)</summary>
+          <p class="mono">${body.seller_token}</p>
+        </details>
+        <hr style="margin-block:1.5rem" />
+        <p class="meta">
+          このトークンを使ったメディアアップロード + イベント発行 UI は次の PR (c2) でこの場所に追加されます。
+          現状ではこのページは「OID4VP のプロバイダ側ループが動く」ことの確認用です。
+        </p>
+      `;
+    }
+
+    function renderDeny(result) {
+      const root = document.getElementById("root");
+      const msg = result.human_message_ja
+               || result.human_message_en
+               || `Presentation denied (${result.reason || "unknown"}).`;
+      root.innerHTML = `
+        <div class="err">
+          <strong>提示が拒否されました</strong><br />
+          ${msg}
+        </div>
+        <p class="meta">
+          reason code: <code>${result.reason || ""}</code>
+        </p>
+        <p>
+          別の VC で試す場合は<a href="" onclick="location.reload();return false;">このページをリロード</a>してください。
+        </p>
+      `;
+    }
+
+    bootstrap();
+  </script>
+</body>
+</html>
+"""

--- a/publisher/app/ssi/config.py
+++ b/publisher/app/ssi/config.py
@@ -11,7 +11,7 @@ class SSISettings(BaseSettings):
     issuer_key_path: str = "/data/issuer_key.jwk.json"
     issuer_id: str = "iw3ip-publisher-issuer"
     credential_ttl_days: int = 365
-    offer_ttl_seconds: int = 600
+    offer_ttl_seconds: int = 1800
     pex_sidecar_url: str = "http://verifier-sidecar:7000"
     presentation_defs_dir: str = "/app/examples/ssi_wallet"
     response_ttl_seconds: int = 600

--- a/publisher/app/ssi/verifier_routes.py
+++ b/publisher/app/ssi/verifier_routes.py
@@ -639,7 +639,7 @@ def build_router(deps: VerifierDeps) -> APIRouter:
                     seller_st.licensed_datasets,
                     int(seller_st.expires_at - seller_st.issued_at),
                 )
-                return {
+                resp = {
                     "status": "allowed",
                     "vc_kind": "SellerVC",
                     "seller_token": seller_st.token,
@@ -648,6 +648,34 @@ def build_router(deps: VerifierDeps) -> APIRouter:
                     "licensed_datasets": seller_st.licensed_datasets,
                     "expires_in": int(seller_st.expires_at - seller_st.issued_at),
                 }
+                # Stage T (PWA provider, c1):
+                # mirror what PurchaseViewerVC does -- stash the seller_token
+                # onto VerificationRequest.result so /verifier/status
+                # (long-poll) can echo it for the cross-device flow, and
+                # add an OID4VP redirect_uri pointing back at /provider/start
+                # with the same `state` so same-device flow can resume the
+                # poll after the wallet bounces back.
+                deps.state.record_verification_result(
+                    state,
+                    {
+                        "verified": True,
+                        "reason": reason,
+                        "seller_token": seller_st.token,
+                        "seller_token_jti": seller_st.jti,
+                        "seller_id": claims.get("seller_id"),
+                        "licensed_datasets": list(seller_st.licensed_datasets),
+                        "expires_in": int(seller_st.expires_at - seller_st.issued_at),
+                        "vc_kind": "SellerVC",
+                    },
+                )
+                public_base = externally_reachable_base_url(
+                    request, deps.settings.issuer_base_url
+                )
+                resp["redirect_uri"] = (
+                    f"{public_base.rstrip('/')}/provider/start"
+                    f"?state={urllib.parse.quote(state)}"
+                )
+                return resp
             if req.vc_kind == "DataUserVC":
                 # No token minted: DataUserVC presentation is informational
                 # (the publisher just confirms it can compute the trust score
@@ -766,6 +794,14 @@ def build_router(deps: VerifierDeps) -> APIRouter:
                 f"?vt={result['viewer_token']}"
                 f"&ds={urllib.parse.quote(req.dataset_id)}"
             )
+        # Stage T (PWA provider, c1): same idea for SellerVC. The polling
+        # /provider/start page only needs the seller_token + licensed_datasets
+        # to render its inline success panel; it does not navigate away.
+        if isinstance(result, dict) and result.get("verified") and result.get("seller_token"):
+            out["seller_token"] = result["seller_token"]
+            out["licensed_datasets"] = result.get("licensed_datasets") or []
+            out["expires_in"] = result.get("expires_in")
+            out["seller_id"] = result.get("seller_id")
         return out
 
     return router

--- a/tests/test_ssi_seller_token.py
+++ b/tests/test_ssi_seller_token.py
@@ -190,3 +190,112 @@ def test_seller_token_unknown(client):
     _, pm = client
     _, reason = pm.ssi_state.use_seller_token("bogus", dataset_id="home/env/temperature")
     assert reason == "unknown"
+
+
+# ---- Stage T (PWA provider, c1): /provider/start + cross-device polling ----
+
+
+def test_provider_start_page_renders_html(client):
+    tc, _ = client
+    r = tc.get("/provider/start", params={"ds": "home/env/temperature"})
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/html")
+    body = r.text
+    # Page should hard-code SellerVC as the vc_kind it asks for and
+    # bootstrap /verifier/request itself.
+    assert "SellerVC" in body
+    assert "/verifier/request" in body
+    assert "/verifier/status" in body
+    # Dataset hint should land in the page (so audit logs see what the
+    # provider intended even though SellerVC isn't dataset-bound).
+    assert "home/env/temperature" in body
+    # QR rendering is client-side via qrcode-svg CDN.
+    assert "qrcode" in body.lower() or "QRCode" in body
+
+
+def test_provider_start_accepts_optional_ds(client):
+    """ds is optional -- SellerVC verification isn't dataset-scoped, the
+    page just shows the hint when given."""
+    tc, _ = client
+    r = tc.get("/provider/start")
+    assert r.status_code == 200
+    assert "SellerVC" in r.text
+
+
+def test_seller_vc_response_returns_redirect_uri_to_provider_start(client):
+    """c1: a successful SellerVC presentation must echo a redirect_uri
+    pointing back at /provider/start?state=... so same-device wallets
+    can bounce the user back to the polling page."""
+    tc, _ = client
+    # _issue_seller_token already asserts status == "allowed".
+    # Inspect the raw /verifier/response by mirroring its setup.
+    priv, pub, _ = _holder()
+    offer = tc.get(
+        "/issuer/offer",
+        params={"type": "SellerVC", "seller_id": "ertl-001",
+                "licensed_datasets": "home/env/temperature"},
+        headers={"accept": "application/json"},
+    ).json()
+    token = tc.post(
+        "/issuer/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:pre-authorized_code",
+            "pre-authorized_code": offer["pre_authorized_code"],
+        },
+    ).json()
+    proof = _proof(priv, pub, token["c_nonce"], "http://testserver")
+    cred = tc.post(
+        "/issuer/credential",
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+        json={
+            "format": "vc+sd-jwt",
+            "vct": "https://iw3ip.example/credentials/SellerVC/v1",
+            "proof": {"proof_type": "jwt", "jwt": proof},
+        },
+    ).json()
+    req = tc.get(
+        "/verifier/request",
+        params={"vc_kind": "SellerVC"},
+        headers={"accept": "application/json"},
+    ).json()
+    state = req["authorization_request"]["state"]
+    sub = {
+        "id": "sub-seller-vc",
+        "definition_id": "seller-vc",
+        "descriptor_map": [{"id": "seller_vc", "format": "vc+sd-jwt", "path": "$"}],
+    }
+    body = tc.post(
+        "/verifier/response",
+        data={
+            "vp_token": cred["credential"],
+            "presentation_submission": json.dumps(sub),
+            "state": state,
+        },
+    ).json()
+    assert body["status"] == "allowed"
+    assert body["vc_kind"] == "SellerVC"
+    assert "redirect_uri" in body, body
+    # Must point at /provider/start with the same state so the resume
+    # branch in the page-side script picks it up.
+    assert "/provider/start" in body["redirect_uri"]
+    assert f"state={state}" in body["redirect_uri"]
+
+
+def test_verifier_status_surfaces_seller_token_after_success(client):
+    """c1: cross-device polling -- once SellerVC has been presented,
+    /verifier/status must echo seller_token + licensed_datasets so the
+    /provider/start page can render its inline success panel."""
+    tc, pm = client
+    seller_token, licensed = _issue_seller_token(tc)
+    # Most recent verification request state corresponds to the SellerVC
+    # presentation just issued by the helper.
+    state = list(pm.ssi_state._requests.keys())[-1]
+    r = tc.get("/verifier/status", params={"state": state})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["seller_token"] == seller_token
+    assert sorted(body["licensed_datasets"]) == sorted(licensed)
+    assert body["seller_id"] == "ertl-001"
+    # Inner result must record the verified=True branch.
+    assert body["result"]["verified"] is True
+    assert body["result"]["vc_kind"] == "SellerVC"


### PR DESCRIPTION
## Summary
- Mirror of `/buyer/start` for the data-provider side: PWA page that handles SellerVC presentation end-to-end (QR or deeplink → wallet → SellerToken).
- Hooks the existing SellerVC verification path into the long-poll plumbing so `/verifier/status` surfaces `seller_token` + `licensed_datasets` to the page (parallels how `viewer_token` is hoisted today).
- Adds `redirect_uri` pointing at `/provider/start?state=…` so same-device wallets bounce the user back to a page that skips bootstrap and resumes the poll.

## Why split this from c2
This PR is the OID4VP plumbing only. Reviewers can verify the SellerVC presentation flow lights up end-to-end without also reading the upload/publish UI. The actual `<input type=file>` → `/media/upload` → `/simulate/publish` UI and Bearer-SellerToken gating land in **c2**.

## Out of scope (c2 / c3)
- The `/provider` page itself
- Gating `/media/upload` and `/simulate/publish` on a Bearer SellerToken (with `licensed_datasets` check)
- Hands-on docs §11 walkthrough

## Test plan
- [x] `pytest tests/test_ssi_seller_token.py` — 13/13 pass (4 new + 9 existing)
- [x] `pytest tests/test_data_user_vc_tiered.py tests/test_ssi_viewer_token.py tests/test_ssi_seller_token.py` — 62/62 pass, no regressions
- [ ] Real-device: PC opens `/provider/start`, scan QR with iPhone wallet holding a SellerVC → page should show "SellerVC 提示が承認されました" panel with licensed_datasets list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
