### PR TITLE
feat(provider): Stage T (c2) — /provider page + Bearer-gated publish

### DIFF
--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -120,10 +120,18 @@ app.include_router(
 # Edge, Firefox.
 app.include_router(build_viewer_router())
 
-# Stage T (PWA provider, c1): /provider/start renders the provider-side
-# OID4VP loop (SellerVC presentation -> SellerToken). The actual
-# upload + publish UI lands in c2.
-app.include_router(build_provider_router())
+# Stage T (PWA provider): /provider/start (c1) + /provider (c2) +
+# /provider/publish (c2). The first two are HTML pages; the third is
+# a Bearer-SellerToken-gated wrapper around processor.process_message
+# whose dataset (resolved from the topic) must be in the SellerToken's
+# licensed_datasets.
+app.include_router(
+    build_provider_router(
+        ssi_state=ssi_state,
+        processor=processor,
+        audit_repo=audit_repo,
+    )
+)
 
 
 @app.on_event("startup")

--- a/publisher/app/provider_routes.py
+++ b/publisher/app/provider_routes.py
@@ -1,54 +1,65 @@
-"""Stage T (PWA provider, c1) -- minimal browser UI for data providers.
+"""Stage T (PWA provider) -- browser UI for data providers.
 
-Mirror of /buyer/start but for SellerVC presentation. The page bootstraps
-a /verifier/request?vc_kind=SellerVC, shows a QR for cross-device flow
-(or jumps to the wallet for same-device), and on success renders an
-inline panel showing the SellerToken + licensed_datasets.
+Three routes ship together:
 
-The actual upload + /simulate/publish UI ships in c2; for c1 the page
-only proves that the OID4VP plumbing for the provider side works
-end-to-end (QR -> wallet -> SellerVC presentation -> SellerToken issued
-and surfaced back to the page).
+* ``GET /provider/start`` (c1) -- bootstraps the SellerVC OID4VP loop
+  (UA-aware: phone deeplink vs. PC QR + long-poll). On success the
+  page navigates to ``/provider`` with the freshly-minted SellerToken.
 
-Same-device flow uses redirect_uri=/provider/start?state=... which the
-client-side script picks up to skip the bootstrap step and just resume
-polling.
+* ``GET /provider`` (c2) -- the actual upload + publish UI. Accepts
+  ``?pt=<seller_token>&ds=<dataset_id>``, lets the provider pick an
+  image / video / event JSON, calls /media/upload, and POSTs the
+  resulting payload to /provider/publish.
+
+* ``POST /provider/publish`` (c2) -- Bearer-SellerToken-gated wrapper
+  around ``processor.process_message``. The dataset (derived from the
+  topic, same as /simulate/publish) must be in the SellerToken's
+  ``licensed_datasets`` -- enforced via the multi-use ``use_seller_token``
+  helper. ``/media/upload`` itself stays open: the URL it returns is
+  the access token (same model the buyer side uses for /platform/data).
 """
 from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime, timezone
+from typing import Any
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Body, Header, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
+
+from audit.models import AuditLogRecord
+from audit.repository import SQLiteAuditRepository
+from publisher.app.models import SimulatePublishRequest
+from publisher.app.pipeline import MessageProcessor
+from publisher.app.ssi.state import SSIStateStore
 
 
 logger = logging.getLogger(__name__)
 
 
-def build_router() -> APIRouter:
+def _bearer_token(authorization: str | None) -> str:
+    if not authorization:
+        raise HTTPException(status_code=401, detail="missing_authorization_header")
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(status_code=401, detail="invalid_authorization_header")
+    return token
+
+
+def build_router(
+    *,
+    ssi_state: SSIStateStore,
+    processor: MessageProcessor,
+    audit_repo: SQLiteAuditRepository,
+) -> APIRouter:
     router = APIRouter()
 
     @router.get("/provider/start", response_class=HTMLResponse)
     def provider_start_page(
         request: Request,
-        ds: str | None = Query(
-            default=None,
-            description=(
-                "Optional dataset hint -- shown in the page header so the "
-                "provider knows which dataset they're about to publish to. "
-                "SellerVC verification itself is not dataset-bound; the "
-                "licensed_datasets check happens server-side at upload time."
-            ),
-        ),
-        state: str | None = Query(
-            default=None,
-            description=(
-                "Existing verifier state to resume polling against. Set by "
-                "the wallet's redirect_uri after a same-device presentation "
-                "so the page skips the bootstrap step."
-            ),
-        ),
+        ds: str | None = Query(default=None),
+        state: str | None = Query(default=None),
     ) -> HTMLResponse:
         page_origin = str(request.base_url).rstrip("/")
         safe = lambda v: json.dumps(v if v is not None else "")  # noqa: E731
@@ -60,11 +71,82 @@ def build_router() -> APIRouter:
         )
         return HTMLResponse(body)
 
+    @router.get("/provider", response_class=HTMLResponse)
+    def provider_page(
+        request: Request,
+        pt: str = Query(..., description="SellerToken (Bearer for /provider/publish)"),
+        ds: str = Query(..., description="dataset_id to publish to"),
+    ) -> HTMLResponse:
+        page_origin = str(request.base_url).rstrip("/")
+        safe = lambda v: json.dumps(v)  # noqa: E731
+        body = (
+            _PROVIDER_HTML
+            .replace("__ORIGIN__", safe(page_origin))
+            .replace("__PT__", safe(pt))
+            .replace("__DS__", safe(ds))
+        )
+        return HTMLResponse(body)
+
+    @router.post("/provider/publish")
+    def provider_publish(
+        req: SimulatePublishRequest,
+        authorization: str | None = Header(default=None),
+    ) -> dict:
+        """Bearer-SellerToken wrapper around processor.process_message.
+
+        Dataset is derived from the topic via the same normalize() pipeline
+        /simulate/publish uses; we then check the resolved dataset_id
+        against the SellerToken's licensed_datasets list.
+        """
+        token = _bearer_token(authorization)
+
+        # Resolve dataset_id from the topic+payload before we look up the
+        # SellerToken so the licensed_datasets check is meaningful even
+        # when the topic itself is well-formed but the dataset isn't
+        # licensed.
+        from schemas.models import normalize  # local import: schemas is heavy
+
+        try:
+            normalized = normalize(req.topic, req.payload)
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=f"unsupported_topic:{exc}")
+        dataset_id = normalized.dataset_id
+
+        seller_token, reason = ssi_state.use_seller_token(token, dataset_id=dataset_id)
+        if not seller_token:
+            audit_repo.write(
+                AuditLogRecord(
+                    ts=datetime.now(timezone.utc).isoformat(),
+                    action="deny",
+                    subject_did="unknown",
+                    dataset_id=dataset_id,
+                    purpose=req.purpose or "publish",
+                    reason=f"seller_token_{reason}",
+                    message_hash="",
+                    raw_topic=req.topic,
+                    holder_did=None,
+                    vc_hash=None,
+                    presentation_verified="deny",
+                )
+            )
+            status = 401 if reason in ("unknown", "expired") else 403
+            raise HTTPException(status_code=status, detail=f"seller_token_{reason}")
+
+        result: dict[str, Any] = processor.process_message(
+            req.topic, req.payload, req.purpose
+        )
+        # Keep the SellerToken-derived identity in the response so the
+        # /provider page can show the provider who authored what.
+        result["seller_did"] = seller_token.seller_did
+        result["seller_token_jti"] = seller_token.jti
+        result["register_count"] = seller_token.register_count
+        return result
+
     return router
 
 
 # ----------------------------------------------------------------------
-# /provider/start page template
+# /provider/start page template (c1)
 # ----------------------------------------------------------------------
 _PROVIDER_START_HTML = r"""<!DOCTYPE html>
 <html lang="ja">
@@ -94,15 +176,23 @@ _PROVIDER_START_HTML = r"""<!DOCTYPE html>
       text-decoration: none; margin-block: 0.5rem;
     }
     .pulse { animation: pulse 1.4s ease-in-out infinite; }
-    @keyframes pulse {
-      0%, 100% { opacity: 0.55; }
-      50% { opacity: 1; }
-    }
+    @keyframes pulse { 0%, 100% { opacity: 0.55; } 50% { opacity: 1; } }
     code, .mono {
       font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
       font-size: 0.85rem; word-break: break-all;
     }
     ul.licensed { padding-inline-start: 1.2rem; }
+    .ds-pick {
+      display: flex; gap: 0.5rem; align-items: center;
+      margin-top: 1rem; flex-wrap: wrap;
+    }
+    .ds-pick input { flex: 1 1 240px; padding: 0.4rem; }
+    .btn {
+      display: inline-block; padding: 0.5rem 1rem; border-radius: 6px;
+      background: #2e7d32; color: #fff; text-decoration: none;
+      border: 0; cursor: pointer; font-size: 0.95rem;
+    }
+    .btn[disabled] { background: #aaa; cursor: not-allowed; }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/qrcode-svg@1.1.0/dist/qrcode.min.js"></script>
 </head>
@@ -124,22 +214,14 @@ _PROVIDER_START_HTML = r"""<!DOCTYPE html>
 
     async function bootstrap() {
       const root = document.getElementById("root");
-
-      // Same-device return path: the wallet's redirect_uri brought us
-      // back with ?state=... already set. Skip /verifier/request and
-      // resume polling immediately.
       if (RESUME_STATE) {
         root.innerHTML = `<p class="pulse">ウォレットからの戻りを処理中…</p>`;
         pollUntilDone(RESUME_STATE);
         return;
       }
-
       try {
         const url = new URL(`${ORIGIN}/verifier/request`);
         url.searchParams.set("vc_kind", VC_KIND);
-        // SellerVC isn't dataset-scoped at verify time; verifier_routes
-        // accepts "*" as a sentinel. Pass the hint along anyway so audit
-        // logs see what the provider intended.
         url.searchParams.set("dataset_id", DS_HINT || "*");
         url.searchParams.set("purpose", "publish");
         const r = await fetch(url, { headers: { Accept: "application/json" } });
@@ -157,9 +239,6 @@ _PROVIDER_START_HTML = r"""<!DOCTYPE html>
           return;
         }
         if (isMobile) {
-          // Same-device: jump to the wallet. Wallet's redirect_uri
-          // returns the user to /provider/start?state=... which the
-          // RESUME_STATE branch above picks up.
           root.innerHTML = `
             <p>📱 ウォレットを起動しています…</p>
             <a class="deeplink" href="${deeplink}">ウォレットで開く</a>
@@ -201,8 +280,6 @@ _PROVIDER_START_HTML = r"""<!DOCTYPE html>
           );
           if (r.ok) {
             const body = await r.json();
-            // Success: SellerToken minted. /verifier/status surfaces
-            // seller_token + licensed_datasets directly.
             if (body.seller_token) {
               renderSuccess(body);
               return;
@@ -218,7 +295,7 @@ _PROVIDER_START_HTML = r"""<!DOCTYPE html>
             return;
           }
         } catch (e) {
-          // transient error, keep polling
+          // transient
         }
         await new Promise(r => setTimeout(r, 2000));
       }
@@ -227,27 +304,41 @@ _PROVIDER_START_HTML = r"""<!DOCTYPE html>
     function renderSuccess(body) {
       const root = document.getElementById("root");
       const licensed = body.licensed_datasets || [];
-      const items = licensed.map(d => `<li><code>${d}</code></li>`).join("") || "<li><em>(none)</em></li>";
+      // c2: when DS_HINT is one of the licensed datasets, we can offer
+      // a "go straight to /provider" button. Otherwise we let the user
+      // pick from licensed_datasets.
+      const preselected = licensed.includes(DS_HINT) ? DS_HINT : (licensed[0] || "");
+      const items = licensed.map(d =>
+        `<li><label><input type="radio" name="ds" value="${d}" ${d === preselected ? "checked" : ""} /> <code>${d}</code></label></li>`
+      ).join("") || "<li><em>(none)</em> — このウォレットにはまだデータセットが付与されていません</li>";
       const expIn = body.expires_in ? `${Math.round(body.expires_in / 60)} 分` : "—";
       root.innerHTML = `
         <div class="ok">
           <strong>SellerVC 提示が承認されました</strong><br />
           ProviderToken (= SellerToken) を発行しました。
         </div>
-        <h2 style="font-size:1rem;margin-top:1.5rem">出品許可データセット</h2>
-        <ul class="licensed">${items}</ul>
+        <h2 style="font-size:1rem;margin-top:1.5rem">出品許可データセット — 1 つ選んでください</h2>
+        <ul class="licensed" id="dsList">${items}</ul>
         <p class="meta">seller_id: <code>${body.seller_id || "—"}</code></p>
         <p class="meta">有効期限: ${expIn}</p>
+        <div class="ds-pick">
+          <button class="btn" id="goProvider" ${licensed.length ? "" : "disabled"}>
+            選んだデータセットでアップロードへ進む →
+          </button>
+        </div>
         <details style="margin-top:1rem">
           <summary>SellerToken (debug)</summary>
           <p class="mono">${body.seller_token}</p>
         </details>
-        <hr style="margin-block:1.5rem" />
-        <p class="meta">
-          このトークンを使ったメディアアップロード + イベント発行 UI は次の PR (c2) でこの場所に追加されます。
-          現状ではこのページは「OID4VP のプロバイダ側ループが動く」ことの確認用です。
-        </p>
       `;
+      document.getElementById("goProvider").addEventListener("click", () => {
+        const sel = document.querySelector('input[name="ds"]:checked');
+        if (!sel) return;
+        const u = new URL(`${ORIGIN}/provider`);
+        u.searchParams.set("pt", body.seller_token);
+        u.searchParams.set("ds", sel.value);
+        window.location.href = u.toString();
+      });
     }
 
     function renderDeny(result) {
@@ -260,9 +351,7 @@ _PROVIDER_START_HTML = r"""<!DOCTYPE html>
           <strong>提示が拒否されました</strong><br />
           ${msg}
         </div>
-        <p class="meta">
-          reason code: <code>${result.reason || ""}</code>
-        </p>
+        <p class="meta">reason code: <code>${result.reason || ""}</code></p>
         <p>
           別の VC で試す場合は<a href="" onclick="location.reload();return false;">このページをリロード</a>してください。
         </p>
@@ -270,6 +359,242 @@ _PROVIDER_START_HTML = r"""<!DOCTYPE html>
     }
 
     bootstrap();
+  </script>
+</body>
+</html>
+"""
+
+
+# ----------------------------------------------------------------------
+# /provider page template (c2)
+# ----------------------------------------------------------------------
+_PROVIDER_HTML = r"""<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>IW3IP Provider — Upload &amp; Publish</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      margin: 0; padding: 1rem; max-width: 760px; margin-inline: auto;
+      line-height: 1.5;
+    }
+    h1 { font-size: 1.2rem; margin-block-start: 0; }
+    fieldset { border: 1px solid #ccc; border-radius: 8px; margin-block: 1rem; padding: 1rem; }
+    legend { font-weight: 600; padding: 0 0.5rem; }
+    label { display: block; margin-block: 0.4rem 0.2rem; font-size: 0.9rem; color: #555; }
+    input[type=text], input[type=number], textarea, select {
+      width: 100%; padding: 0.4rem; box-sizing: border-box; font-size: 0.95rem;
+    }
+    textarea { min-height: 6em; font-family: ui-monospace, Menlo, monospace; }
+    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 0.6rem; }
+    .meta { font-size: 0.85rem; color: #666; }
+    .err { padding: 0.75rem; background: #fdecea; border-radius: 6px; color: #b71c1c; margin-block: 0.5rem; }
+    .ok  { padding: 0.75rem; background: #e8f5e9; border-radius: 6px; color: #1b5e20; margin-block: 0.5rem; }
+    pre { background: #1e1e1e; color: #eaeaea; padding: 0.75rem; border-radius: 6px; overflow: auto; font-size: 0.78rem; }
+    .btn {
+      display: inline-block; padding: 0.55rem 1rem; border-radius: 6px;
+      background: #2e7d32; color: #fff; text-decoration: none;
+      border: 0; cursor: pointer; font-size: 0.95rem;
+    }
+    .btn.secondary { background: #455a64; }
+    .btn[disabled] { background: #aaa; cursor: not-allowed; }
+    .preview img, .preview video {
+      max-width: 100%; max-height: 240px; border-radius: 6px; background: #f3f3f3;
+    }
+    .row-fields { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+    .pill {
+      background: rgba(46,125,50,0.12); color: #1b5e20;
+      padding: 2px 8px; border-radius: 999px; font-size: 0.75rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>IW3IP Provider — Upload &amp; Publish</h1>
+  <p class="meta" id="meta"></p>
+
+  <fieldset>
+    <legend>1. メディアをアップロード <span class="pill">/media/upload</span></legend>
+    <p class="meta">画像 (JPEG / PNG / WebP) または動画 (MP4 / WebM) を選んでください。SHA-256 で重複排除されるので同じファイルの再アップロードは無料です。</p>
+    <input type="file" id="file" accept="image/*,video/*" />
+    <div class="preview" id="preview"></div>
+    <div id="uploadResult"></div>
+  </fieldset>
+
+  <fieldset>
+    <legend>2. イベントを発行 <span class="pill">POST /provider/publish</span></legend>
+    <div class="row">
+      <div>
+        <label>topic</label>
+        <input type="text" id="topic" />
+      </div>
+      <div>
+        <label>purpose</label>
+        <input type="text" id="purpose" value="community_cleaning" />
+      </div>
+    </div>
+    <div class="row">
+      <div>
+        <label>camera_id (event payload)</label>
+        <input type="text" id="cameraId" value="webcam-401" />
+      </div>
+      <div>
+        <label>video_duration_sec</label>
+        <input type="number" id="videoDuration" value="12" min="0" />
+      </div>
+    </div>
+    <label>extra payload keys (JSON, merged into event payload — optional)</label>
+    <textarea id="extraJson" placeholder='{"weather":"clear"}'></textarea>
+    <div class="row-fields" style="margin-top: 0.7rem">
+      <button class="btn" id="publishBtn" disabled>Publish event</button>
+      <span class="meta" id="publishHint">先にメディアをアップロードしてください</span>
+    </div>
+    <div id="publishResult"></div>
+  </fieldset>
+
+  <fieldset>
+    <legend>3. 受信側で確認</legend>
+    <p class="meta">
+      この dataset の受信側 PWA は
+      <a id="buyerLink" target="_blank" rel="noopener noreferrer">/buyer/start</a>
+      から開けます（Tier 3 の PurchaseViewerVC を提示してください）。
+    </p>
+  </fieldset>
+
+  <script>
+    const ORIGIN = __ORIGIN__;
+    const PT = __PT__;
+    const DS = __DS__;
+
+    document.getElementById("meta").textContent = `dataset_id=${DS}`;
+    // event topic defaults to "homeassistant/event/<last-segment-of-ds>"
+    const lastSeg = DS.split("/").pop();
+    document.getElementById("topic").value = `homeassistant/event/${lastSeg}`;
+    const buyerLink = document.getElementById("buyerLink");
+    const buyerUrl = new URL(`${ORIGIN}/buyer/start`);
+    buyerUrl.searchParams.set("ds", DS);
+    buyerLink.href = buyerUrl.toString();
+    buyerLink.textContent = buyerUrl.toString();
+
+    let lastUpload = null; // { url, cid, ipfs_gateway_url, content_type, byte_size }
+    const fileInput = document.getElementById("file");
+    const preview = document.getElementById("preview");
+    const uploadResult = document.getElementById("uploadResult");
+    const publishBtn = document.getElementById("publishBtn");
+    const publishHint = document.getElementById("publishHint");
+
+    fileInput.addEventListener("change", async () => {
+      const f = fileInput.files?.[0];
+      preview.innerHTML = "";
+      uploadResult.innerHTML = "";
+      if (!f) {
+        publishBtn.disabled = true;
+        publishHint.textContent = "先にメディアをアップロードしてください";
+        return;
+      }
+
+      // local preview
+      const url = URL.createObjectURL(f);
+      const isImg = f.type.startsWith("image/");
+      const tag = document.createElement(isImg ? "img" : "video");
+      tag.src = url;
+      if (!isImg) tag.controls = true;
+      preview.appendChild(tag);
+
+      // upload to /media/upload (open by design)
+      uploadResult.innerHTML = `<p class="meta">アップロード中…</p>`;
+      const fd = new FormData();
+      fd.append("file", f);
+      try {
+        const r = await fetch(`${ORIGIN}/media/upload`, { method: "POST", body: fd });
+        const text = await r.text();
+        if (!r.ok) {
+          uploadResult.innerHTML = `<div class="err">HTTP ${r.status}: ${text}</div>`;
+          return;
+        }
+        lastUpload = JSON.parse(text);
+        const cidLine = lastUpload.cid
+          ? `<br /><span class="meta">CID: <code>${lastUpload.cid}</code></span>`
+          : "";
+        uploadResult.innerHTML = `
+          <div class="ok">
+            <strong>アップロード完了</strong><br />
+            URL: <a href="${lastUpload.url}" target="_blank" rel="noopener noreferrer">${lastUpload.url}</a>
+            ${cidLine}
+            <br /><span class="meta">${lastUpload.content_type} • ${lastUpload.byte_size} bytes • sha256=${lastUpload.sha256.slice(0, 12)}…</span>
+          </div>
+        `;
+        publishBtn.disabled = false;
+        publishHint.textContent = "発行する内容を確認して Publish を押してください";
+      } catch (e) {
+        uploadResult.innerHTML = `<div class="err">network error: ${e.message || e}</div>`;
+      }
+    });
+
+    publishBtn.addEventListener("click", async () => {
+      const topic = document.getElementById("topic").value.trim();
+      const purpose = document.getElementById("purpose").value.trim();
+      const cameraId = document.getElementById("cameraId").value.trim();
+      const videoDuration = parseInt(document.getElementById("videoDuration").value, 10) || 0;
+      let extra = {};
+      const extraText = document.getElementById("extraJson").value.trim();
+      if (extraText) {
+        try {
+          extra = JSON.parse(extraText);
+        } catch (e) {
+          document.getElementById("publishResult").innerHTML =
+            `<div class="err">extra JSON のパースに失敗: ${e.message}</div>`;
+          return;
+        }
+      }
+
+      const isImage = (lastUpload?.content_type || "").startsWith("image/");
+      const payload = {
+        ts: new Date().toISOString(),
+        source: "iw3ip-provider-page",
+        event_type: "possible_littering",
+        camera_id: cameraId,
+        ...(isImage
+          ? { image_url: lastUpload.url }
+          : { video_url: lastUpload.url, video_duration_sec: videoDuration }),
+        ...(lastUpload?.cid ? { image_cid: lastUpload.cid } : {}),
+        data: {
+          purpose,
+          dataset_id: DS,
+        },
+        ...extra,
+      };
+
+      const out = document.getElementById("publishResult");
+      out.innerHTML = `<p class="meta">Publish 中…</p>`;
+      try {
+        const r = await fetch(`${ORIGIN}/provider/publish`, {
+          method: "POST",
+          headers: {
+            "Authorization": `Bearer ${PT}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ topic, payload, purpose }),
+        });
+        const text = await r.text();
+        if (!r.ok) {
+          out.innerHTML = `<div class="err">HTTP ${r.status}: ${text}</div>`;
+          return;
+        }
+        const body = JSON.parse(text);
+        out.innerHTML = `
+          <div class="ok">
+            <strong>Published</strong>
+            <br /><span class="meta">status=${body.status} • dataset=${body.dataset_id || DS}</span>
+          </div>
+          <details><summary>response (raw)</summary><pre>${JSON.stringify(body, null, 2)}</pre></details>
+        `;
+      } catch (e) {
+        out.innerHTML = `<div class="err">network error: ${e.message || e}</div>`;
+      }
+    });
   </script>
 </body>
 </html>

--- a/tests/test_ssi_seller_token.py
+++ b/tests/test_ssi_seller_token.py
@@ -299,3 +299,212 @@ def test_verifier_status_surfaces_seller_token_after_success(client):
     # Inner result must record the verified=True branch.
     assert body["result"]["verified"] is True
     assert body["result"]["vc_kind"] == "SellerVC"
+
+
+# ---- Stage T (PWA provider, c2): /provider page + /provider/publish ----
+
+
+def _seed_consent(pm, dataset_id: str, purposes: list[str]) -> None:
+    """Drop a ConsentVC into the publisher's in-process consent_store so
+    /provider/publish has something to match against. Mirrors how the
+    Stage T case-B/C tests bootstrap consent state. Also stubs out
+    platform_client.send so the pipeline doesn't try to ship the
+    accepted message to a non-existent HTTP endpoint during tests.
+    """
+    from datetime import datetime, timezone, timedelta
+    from policy.models import ConsentVC
+
+    now = datetime.now(timezone.utc)
+    pm.consent_store.upsert(
+        ConsentVC(
+            vc_id=f"c-provider-{dataset_id.replace('/', '-')}",
+            subject_did="did:example:provider",
+            dataset_id=dataset_id,
+            allowed_purposes=purposes,
+            retention_days=14,
+            reshare_allowed=False,
+            valid_from=now - timedelta(days=1),
+            valid_to=now + timedelta(days=30),
+            signature="x",
+        )
+    )
+    # In-process sink so process_message doesn't 500 on a missing platform
+    # endpoint and we can still assert status == "allowed".
+    sent: list[dict] = []
+    pm.processor.platform_client = type(
+        "_Sink", (), {"send": lambda self, env: sent.append(env)}
+    )()
+
+
+def test_provider_page_renders_html_with_pt_and_ds(client):
+    tc, _ = client
+    r = tc.get("/provider", params={"pt": "fake-token", "ds": "home/env/temperature"})
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/html")
+    body = r.text
+    # The page hard-codes the token + dataset into the bootstrap script
+    # so the browser knows what to send to /provider/publish.
+    assert "fake-token" in body
+    assert "home/env/temperature" in body
+    # Page wires the two endpoints it talks to.
+    assert "/media/upload" in body
+    assert "/provider/publish" in body
+
+
+def test_provider_page_requires_pt_and_ds(client):
+    tc, _ = client
+    assert tc.get("/provider", params={"pt": "x"}).status_code == 422
+    assert tc.get("/provider", params={"ds": "x"}).status_code == 422
+
+
+def test_provider_publish_succeeds_for_licensed_dataset(client):
+    tc, pm = client
+    _seed_consent(pm, "home/event/possible_littering", ["community_cleaning"])
+    seller_token, _ = _issue_seller_token(
+        tc, licensed="home/event/possible_littering"
+    )
+    r = tc.post(
+        "/provider/publish",
+        headers={"Authorization": f"Bearer {seller_token}"},
+        json={
+            "topic": "homeassistant/event/possible_littering",
+            "purpose": "community_cleaning",
+            "payload": {
+                "event_type": "possible_littering",
+                "ts": "2026-04-29T09:00:00Z",
+                "source": "iw3ip-provider-page",
+                "image_url": "http://testserver/media/aaa.jpg",
+                "data": {"dataset_id": "home/event/possible_littering"},
+            },
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # SellerToken gate passed AND the pipeline accepted the message
+    # (matching ConsentVC seeded above).
+    assert body["status"] == "allowed", body
+    assert body["dataset_id"] == "home/event/possible_littering"
+    assert body.get("seller_token_jti")
+    assert body.get("register_count", 0) >= 1
+
+
+def test_provider_publish_requires_authorization(client):
+    tc, pm = client
+    _seed_consent(pm, "home/event/possible_littering", ["community_cleaning"])
+    r = tc.post(
+        "/provider/publish",
+        json={
+            "topic": "homeassistant/event/possible_littering",
+            "purpose": "community_cleaning",
+            "payload": {
+                "event_type": "possible_littering",
+                "ts": "2026-04-29T09:00:00Z",
+                "source": "iw3ip-provider-page",
+                "data": {},
+            },
+        },
+    )
+    assert r.status_code == 401
+    assert r.json()["detail"] == "missing_authorization_header"
+
+
+def test_provider_publish_rejects_unlicensed_dataset(client):
+    """SellerToken licensed_datasets gate -- the topic resolves to a
+    dataset_id that isn't in the SellerVC's licensed_datasets list."""
+    tc, pm = client
+    _seed_consent(pm, "home/event/possible_littering", ["community_cleaning"])
+    # Issue a SellerToken licensed only for temperature/humidity, then
+    # try to publish to possible_littering.
+    seller_token, _ = _issue_seller_token(
+        tc,
+        licensed="home/env/temperature,home/env/humidity",
+    )
+    r = tc.post(
+        "/provider/publish",
+        headers={"Authorization": f"Bearer {seller_token}"},
+        json={
+            "topic": "homeassistant/event/possible_littering",
+            "purpose": "community_cleaning",
+            "payload": {
+                "event_type": "possible_littering",
+                "ts": "2026-04-29T09:00:00Z",
+                "source": "iw3ip-provider-page",
+                "data": {},
+            },
+        },
+    )
+    assert r.status_code == 403, r.text
+    assert "seller_token_dataset_not_licensed" in r.text
+
+
+def test_provider_publish_rejects_unknown_token(client):
+    tc, _ = client
+    r = tc.post(
+        "/provider/publish",
+        headers={"Authorization": "Bearer not-a-real-token"},
+        json={
+            "topic": "homeassistant/event/possible_littering",
+            "purpose": "community_cleaning",
+            "payload": {
+                "event_type": "possible_littering",
+                "ts": "2026-04-29T09:00:00Z",
+                "source": "iw3ip-provider-page",
+                "data": {},
+            },
+        },
+    )
+    assert r.status_code == 401
+    assert "seller_token_unknown" in r.text
+
+
+def test_provider_publish_rejects_unsupported_topic(client):
+    tc, _ = client
+    seller_token, _ = _issue_seller_token(tc)
+    r = tc.post(
+        "/provider/publish",
+        headers={"Authorization": f"Bearer {seller_token}"},
+        json={
+            "topic": "not/a/real/topic",
+            "purpose": "x",
+            "payload": {},
+        },
+    )
+    assert r.status_code == 400
+    assert "unsupported_topic" in r.text
+
+
+def test_provider_publish_is_multi_use_within_ttl(client):
+    """Multiple events back-to-back under one SellerToken -- mirrors the
+    expected hands-on flow where one wallet presentation covers a whole
+    upload session."""
+    tc, pm = client
+    _seed_consent(pm, "home/event/possible_littering", ["community_cleaning"])
+    seller_token, _ = _issue_seller_token(
+        tc, licensed="home/event/possible_littering"
+    )
+
+    def _publish(idx: int):
+        return tc.post(
+            "/provider/publish",
+            headers={"Authorization": f"Bearer {seller_token}"},
+            json={
+                "topic": "homeassistant/event/possible_littering",
+                "purpose": "community_cleaning",
+                "payload": {
+                    "event_type": "possible_littering",
+                    "ts": "2026-04-29T09:00:00Z",
+                    "source": "iw3ip-provider-page",
+                    "image_url": f"http://testserver/media/img-{idx}.jpg",
+                    "data": {},
+                },
+            },
+        )
+
+    counts: list[int] = []
+    for i in range(3):
+        r = _publish(i)
+        assert r.status_code == 200, r.text
+        counts.append(r.json()["register_count"])
+    # use_seller_token bumps register_count on every successful call.
+    assert counts == sorted(counts)
+    assert counts[-1] >= 3


### PR DESCRIPTION
## Summary
Builds on **c1** ([#36](https://github.com/ertlnagoya/Blockchain_IoT_Marketplace/pull/36)) by adding the actual upload + publish UI and the Bearer-SellerToken gate on the publish path.

- `GET /provider?pt=<seller_token>&ds=<dataset_id>` — file picker + payload editor + publish button
- `POST /provider/publish` — Bearer-SellerToken-gated wrapper around `processor.process_message`. Resolves the dataset from the topic via `schemas.normalize()` and enforces `licensed_datasets` via the existing multi-use `use_seller_token()` helper.
- `/provider/start` success panel now lets the operator pick which licensed dataset to publish to and links straight to `/provider`.

## Why /media/upload stays open
The publisher-side comment at `media_routes.py` is explicit: the URL is the access token. Buyers fetch the same blob via `/media/<sha>` after tier projection without auth, so adding a Bearer requirement to `/media/upload` would create asymmetric auth without changing the threat model. The meaningful gate is at *publish* time (binding the bytes to a dataset).

## Base branch
This PR is **stacked on `feat/stage-t-provider-start-c1`** (c1). Merge c1 first, then GitHub will auto-rebase this onto `main`.

## Test plan
- [x] `pytest tests/test_ssi_seller_token.py` — 21/21 pass (8 new c2 + 13 prior)
- [x] `pytest tests/test_data_user_vc_tiered.py tests/test_ssi_viewer_token.py tests/test_ssi_seller_token.py tests/test_ssi_policy_token.py` — 78/78 pass, no regressions
- [ ] Real-device: scan `/provider/start` QR → present SellerVC → land on `/provider` → upload an image → click Publish → confirm the row appears via `/buyer/start` on the same dataset

## Out of scope
- Hands-on docs §11 walkthrough lands in **c3** (separate PR in `iw3ip.github.io`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
