### PR TITLE
fix(provider): /provider/start must pass dataset_id=* to /verifier/request

### DIFF
--- a/publisher/app/provider_routes.py
+++ b/publisher/app/provider_routes.py
@@ -222,7 +222,13 @@ _PROVIDER_START_HTML = r"""<!DOCTYPE html>
       try {
         const url = new URL(`${ORIGIN}/verifier/request`);
         url.searchParams.set("vc_kind", VC_KIND);
-        url.searchParams.set("dataset_id", DS_HINT || "*");
+        // SellerVC isn't dataset-scoped at verify time; verifier_routes
+        // looks up presentation definitions per (vc_kind, dataset_id)
+        // and only registers SellerVC under the "*" sentinel. Passing
+        // the actual dataset hint here returns 404
+        // no_presentation_definition_for_dataset. The DS_HINT is purely
+        // a display label in the page header above.
+        url.searchParams.set("dataset_id", "*");
         url.searchParams.set("purpose", "publish");
         const r = await fetch(url, { headers: { Accept: "application/json" } });
         if (!r.ok) {

--- a/tests/test_ssi_seller_token.py
+++ b/tests/test_ssi_seller_token.py
@@ -222,6 +222,25 @@ def test_provider_start_accepts_optional_ds(client):
     assert "SellerVC" in r.text
 
 
+def test_provider_start_uses_wildcard_dataset_for_verifier_request(client):
+    """Regression: when the user passes ?ds=home/event/<...> the page
+    must still call /verifier/request with dataset_id=* (SellerVC isn't
+    dataset-scoped at verify time, and the verifier only registers
+    presentation definitions for SellerVC under the "*" sentinel).
+    Previously the page passed the literal hint through, which made the
+    verifier return 404 no_presentation_definition_for_dataset on real
+    devices."""
+    tc, _ = client
+    r = tc.get("/provider/start", params={"ds": "home/event/possible_littering"})
+    body = r.text
+    # The hint should still be visible in the page (display-only).
+    assert "home/event/possible_littering" in body
+    # But the verifier-bootstrap script must hard-code dataset_id="*".
+    assert 'url.searchParams.set("dataset_id", "*")' in body
+    # And it must NOT splice the literal hint into the verifier request.
+    assert 'searchParams.set("dataset_id", DS_HINT' not in body
+
+
 def test_seller_vc_response_returns_redirect_uri_to_provider_start(client):
     """c1: a successful SellerVC presentation must echo a redirect_uri
     pointing back at /provider/start?state=... so same-device wallets


### PR DESCRIPTION
## Summary
Real-device validation found a 404 in the page-side bootstrap: opening `/provider/start?ds=home/event/possible_littering` on iPhone Safari returned

```
HTTP 404: {"detail":"no_presentation_definition_for_dataset"}
```

right after the wallet picked up the request.

## Cause
`verifier_routes` only registers presentation definitions for SellerVC under the `"*"` dataset sentinel — SellerVC isn't dataset-scoped at verify time; the `licensed_datasets` check happens at `/provider/publish`. The c1 page-side JS was splicing the `ds=` hint into `/verifier/request`:

```js
url.searchParams.set("dataset_id", DS_HINT || "*");
```

so any caller that passed a hint hit a 404.

## Fix
Hard-code `dataset_id="*"` in the verifier-bootstrap call. `DS_HINT` remains a display-time label in the page header. Dataset binding still happens at click-through-to-/provider time and again at `/provider/publish` (via `schemas.normalize`).

## Test plan
- [x] `pytest tests/test_ssi_seller_token.py` — 23/23 pass (regression test added: `test_provider_start_uses_wildcard_dataset_for_verifier_request`)
- [x] `curl /provider/start?ds=...` shows `dataset_id", "*"` in the bootstrap script
- [ ] Real-device retry on iPhone Safari (waiting on validator)

## Found by
[iw3ip.github.io#29](https://github.com/ertlnagoya/iw3ip.github.io/pull/29) — scenario A first attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
