### PR TITLE
fix(media): accept iPhone QuickTime (.mov / video/quicktime)

### DIFF
--- a/publisher/app/media_routes.py
+++ b/publisher/app/media_routes.py
@@ -63,6 +63,10 @@ _ALLOWED_EXT = {
     ".mp4": "video/mp4",
     ".webm": "video/webm",
     ".m4v": "video/mp4",
+    # iPhone Safari `<input capture="environment">` saves recorded clips
+    # as QuickTime .mov; without this the /provider page hits 415 right
+    # after the user finishes recording on a phone.
+    ".mov": "video/quicktime",
 }
 
 

--- a/tests/test_data_user_vc_tiered.py
+++ b/tests/test_data_user_vc_tiered.py
@@ -767,6 +767,21 @@ def test_media_upload_rejects_unknown_extension(client):
     assert r.status_code == 415
 
 
+def test_media_upload_accepts_iphone_quicktime(client):
+    """Regression: iPhone Safari's <input capture="environment"> records
+    video as .MOV (QuickTime). The server must accept it -- otherwise
+    the /provider page hits 415 immediately after the user finishes
+    recording on their phone."""
+    tc, _ = client
+    blob = b"\x00\x00\x00\x14ftypqt  \x00\x00\x00\x00qt  " + b"\x00" * 32
+    body, ct = _multipart_body("recorded.MOV", "video/quicktime", blob)
+    r = tc.post("/media/upload", content=body, headers={"Content-Type": ct})
+    assert r.status_code == 200, r.text
+    j = r.json()
+    assert j["content_type"] == "video/quicktime"
+    assert j["url"].endswith(f"/media/{j['sha256']}.mov")
+
+
 def test_media_get_rejects_path_traversal(client):
     tc, _ = client
     # urls with embedded slashes never match the path; this is a belt-and-braces check


### PR DESCRIPTION
## Summary
iPhone Safari's `<input capture="environment">` records video as **QuickTime `.MOV`** (`video/quicktime`). `_ALLOWED_EXT` in `media_routes.py` didn't include it, so `/provider` page recordings on iPhone hit:

```
HTTP 415: {"detail":"unsupported media type; expected one of .gif, .jpeg, .jpg, .m4v, .mp4, .png, .webm, .webp"}
```

right after pressing "ビデオを撮影" and confirming on the iOS camera roll preview.

## Fix
Add `.mov: video/quicktime` to the allowlist. Modern browsers (Safari, Chrome 90+) play it back via the existing `<video>` tag in `/viewer`. Older browsers will surface an inline-playback failure, but the URL itself is still served by `/media/<sha>.mov`.

## Test plan
- [x] `pytest test_media_upload_accepts_iphone_quicktime + adjacent` — 3/3 pass
- [ ] Real-device retry (iPhone scenario A on PR #29)

## Found by
[iw3ip.github.io#29](https://github.com/ertlnagoya/iw3ip.github.io/pull/29) — scenario A second attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
