### PR TITLE
feat(stage-t): VLM tier extension Δ2 — skeleton (stub backends, profile gate)

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -38,6 +38,21 @@ services:
       # off, both env vars stay empty and the gateway runs case B only.
       IPFS_API_URL: ${IPFS_API_URL:-}
       IPFS_GATEWAY_URL: ${IPFS_GATEWAY_URL:-}
+      # Stage T (VLM extension): semantic-level tier projection.
+      # Activate with the `vlm` compose profile -- when the env vars
+      # below are non-empty the publisher generates description_full /
+      # description_summary / image_url_redacted alongside the raw
+      # upload and /platform/data ships them per the tier projection
+      # in trust_score._level_to_views_vlm. When empty the publisher
+      # runs the legacy 3-tier path (image/video keys drop per tier)
+      # exactly as before, so existing tests and demos do not regress.
+      # Backends:
+      #   VLM_BACKEND in {"", "stub", "ollama"}
+      #   IMAGE_REDACTION_BACKEND in {"", "stub", "opencv"}
+      VLM_BACKEND: ${VLM_BACKEND:-}
+      VLM_API_URL: ${VLM_API_URL:-}
+      VLM_MODEL: ${VLM_MODEL:-llava}
+      IMAGE_REDACTION_BACKEND: ${IMAGE_REDACTION_BACKEND:-}
       SSI_ISSUER_BASE_URL: ${SSI_ISSUER_BASE_URL:-http://publisher:8080}
       SSI_ISSUER_KEY_PATH: /data/issuer_key.jwk.json
       SSI_PEX_SIDECAR_URL: http://verifier-sidecar:7000
@@ -110,6 +125,20 @@ services:
     # ports:
     #   - "5001:5001"   # API
     #   - "8081:8080"   # gateway (8081 to avoid collision with publisher)
+
+  # Stage T (VLM extension) — placeholder service for `--profile vlm`.
+  # Δ2 (this PR): empty service definition exists so `docker compose
+  # --profile vlm up` succeeds and the publisher's VLM_BACKEND env var
+  # gets exercised end-to-end with the `stub` backend (no external
+  # model needed for the architecture smoke test).
+  # Δ3 (next PR): replace this with a real Ollama service that loads
+  # `llava` and exposes /api/generate, then flip the publisher's
+  # VLM_BACKEND default to `ollama` under the same profile.
+  vlm:
+    image: alpine:3.20
+    container_name: iw3ip-vlm
+    profiles: ["vlm"]
+    command: ["sh", "-c", "echo 'vlm placeholder (Δ3 will replace with ollama+llava)'; sleep infinity"]
 
 volumes:
   publisher_data:

--- a/publisher/app/config.py
+++ b/publisher/app/config.py
@@ -46,6 +46,42 @@ class Settings(BaseSettings):
     # the registration as "owner_verify=skipped").
     marketplace_hardhat_rpc: str | None = None
 
+    # Stage T (VLM extension): semantic-level tier projection.
+    # Empty string ("") = legacy 3-tier behaviour (drop image/video keys
+    # per access_level). When set, the pipeline produces VLM-derived
+    # keys (description_full / description_summary) and a redacted
+    # image alongside the raw upload, and `allowed_views` gains the
+    # `image_redacted` / `description_full` / `description_summary`
+    # labels. See docs/hands-on/data-user-vc-tiered-spec.md
+    # "Tier extension: semantic-level redaction (VLM)".
+    #
+    # Backends:
+    #   ""        -> disabled (legacy tier projection)
+    #   "stub"    -> deterministic dummy strings (test mode)
+    #   "ollama"  -> POST to OLLAMA_API_URL with VLM_MODEL (Δ3+)
+    vlm_backend: str = ""
+    vlm_api_url: str = ""
+    vlm_model: str = "llava"
+
+    # Image redaction: independent of VLM (face blur doesn't need a
+    # multimodal model). Empty string = disabled. "stub" = passthrough
+    # marker for tests. "opencv" = real Haar-cascade face blur (Δ3).
+    image_redaction_backend: str = ""
+
+    @property
+    def vlm_enabled(self) -> bool:
+        """True when any VLM-tier feature is active.
+
+        Used by trust_score / pipeline / platform_data to switch between
+        legacy 3-tier projection and the 4-tier (full/access/summary/
+        denied) projection. We tie it to vlm_backend (text derivatives)
+        rather than image_redaction_backend so a config that turns on
+        only blur without VLM still falls back to legacy tiering --
+        receivers without `description_summary` shouldn't see a
+        `summary` tier with nothing in it.
+        """
+        return bool(self.vlm_backend)
+
     @property
     def topic_list(self) -> list[str]:
         return [t.strip() for t in self.mqtt_topics.split(",") if t.strip()]

--- a/publisher/app/image_redactor.py
+++ b/publisher/app/image_redactor.py
@@ -1,0 +1,95 @@
+"""Image PII redactor for the Stage T semantic-tier extension.
+
+Backends:
+
+* ``stub`` -- returns the *same* URL marked with a `?redacted=stub`
+  query string so tests / hands-on demos can exercise the pipeline
+  without OpenCV. The marker makes it obvious in /platform/data that
+  the receiver is looking at a placeholder, not a real blur.
+
+* ``opencv`` -- placeholder. Will run Haar-cascade face detection +
+  Gaussian blur and re-upload the result through the existing
+  /media/upload path so the redacted image gets the same dedup +
+  IPFS hooks the originals get. Wires up in Δ3.
+
+Independent from VLM: face-blur doesn't need a multimodal model, so a
+deployment can run blur alone without the description text. The
+pipeline reads each backend separately and emits the corresponding
+``processing_warnings`` entry on failure.
+
+See ``docs/hands-on/data-user-vc-tiered-spec.md`` "Face / PII blur"
+for the schema contract this module implements.
+"""
+from __future__ import annotations
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class RedactionError(Exception):
+    """Base class for any redaction failure. Pipeline catches this and
+    marks the row with `processing_warnings: ["redaction_unavailable"]`."""
+
+
+class RedactionNotImplemented(RedactionError):
+    """Backend recognised but not wired in yet."""
+
+
+class RedactionUnknownBackend(RedactionError):
+    """``settings.image_redaction_backend`` doesn't match a known name."""
+
+
+class ImageRedactor:
+    """Produce ``{image_url_redacted, image_cid_redacted}`` from a
+    source image URL.
+
+    Construct via ``ImageRedactor.from_settings(settings)``; pass
+    through ``None`` when the backend is empty so callers can branch
+    on ``if image_redactor is not None``.
+    """
+
+    def __init__(self, *, backend: str) -> None:
+        self.backend = backend
+
+    @classmethod
+    def from_settings(cls, settings) -> "ImageRedactor | None":
+        if not settings.image_redaction_backend:
+            return None
+        return cls(backend=settings.image_redaction_backend)
+
+    def blur_pii(self, *, image_url: str, content_type: str) -> dict:
+        """Return ``{image_url_redacted, image_cid_redacted}`` (the
+        cid is None when the source wasn't IPFS-backed or the redactor
+        backend doesn't run IPFS uploads).
+
+        Raises ``RedactionError`` on failure -- the pipeline catches
+        and emits ``processing_warnings: ["redaction_unavailable"]``.
+        """
+        # Video sources are not handled by the MVP redactor (frame
+        # extraction + per-frame blur is future work). The Stage T spec
+        # explicitly says Tier 2 video falls back to text-only.
+        if content_type.startswith("video/"):
+            raise RedactionNotImplemented(
+                f"video redaction is future work; got content_type={content_type}"
+            )
+
+        if self.backend == "stub":
+            # Mark the URL so receivers can immediately tell this is a
+            # placeholder, not a real blurred image. We don't host a
+            # second media file; the test asserts the marker is present.
+            sep = "&" if "?" in image_url else "?"
+            return {
+                "image_url_redacted": f"{image_url}{sep}redacted=stub",
+                "image_cid_redacted": None,
+            }
+        if self.backend == "opencv":
+            raise RedactionNotImplemented(
+                "opencv backend is wired in Δ3; configure "
+                "IMAGE_REDACTION_BACKEND=stub for now"
+            )
+        raise RedactionUnknownBackend(
+            f"unknown image redactor backend {self.backend!r}; "
+            f"expected one of: stub, opencv"
+        )

--- a/publisher/app/main.py
+++ b/publisher/app/main.py
@@ -15,9 +15,11 @@ from publisher.app.models import SimulatePublishRequest
 from publisher.app.mqtt_subscriber import MQTTSubscriber
 from publisher.app.pipeline import MessageProcessor
 from publisher.app.platform_client import PlatformClient
+from publisher.app.image_redactor import ImageRedactor
 from publisher.app.media_routes import build_router as build_media_router
 from publisher.app.viewer_routes import build_router as build_viewer_router
 from publisher.app.provider_routes import build_router as build_provider_router
+from publisher.app.vlm_client import VLMClient
 from publisher.app.ssi import issuer_routes, verifier_routes
 from publisher.app.ssi.config import SSISettings
 from publisher.app.ssi.keys import IssuerKeyStore
@@ -35,6 +37,13 @@ audit_repo = SQLiteAuditRepository(settings.audit_db_path)
 policy_engine = PolicyEngine()
 platform_client = PlatformClient(settings.platform_api_url)
 
+# Stage T (VLM extension): both injectors are None when their backend
+# settings are empty -- the pipeline then runs the legacy 3-tier path
+# unchanged. With `--profile vlm` (compose) the env vars get set and
+# the corresponding clients spin up.
+vlm_client = VLMClient.from_settings(settings)
+image_redactor = ImageRedactor.from_settings(settings)
+
 processor = MessageProcessor(
     publisher_id=settings.publisher_id,
     default_purpose=settings.default_purpose,
@@ -42,6 +51,8 @@ processor = MessageProcessor(
     policy_engine=policy_engine,
     audit_repo=audit_repo,
     platform_client=platform_client,
+    vlm_client=vlm_client,
+    image_redactor=image_redactor,
 )
 
 mqtt_subscriber = MQTTSubscriber(
@@ -334,6 +345,14 @@ def platform_data(
     # URL during migration.
     _IMAGE_KEYS = ("image_cid", "image_url")
     _VIDEO_KEYS = ("video_cid", "video_url", "video_duration_sec")
+    # Stage T (VLM extension): image_redacted / description_full /
+    # description_summary are projected alongside the legacy keys.
+    # processing_warnings always passes through so receivers can see
+    # which derivatives were degraded.
+    _IMAGE_REDACTED_KEYS = ("image_url_redacted", "image_cid_redacted")
+    _DESCRIPTION_FULL_KEYS = ("description_full",)
+    _DESCRIPTION_SUMMARY_KEYS = ("description_summary",)
+    _AUDIT_KEYS = ("description_model", "description_generated_at")
 
     def _project(row: dict) -> dict:
         out: dict = {}
@@ -342,6 +361,15 @@ def platform_data(
                 continue
             if k in _VIDEO_KEYS and "video" not in allowed_views:
                 continue
+            if k in _IMAGE_REDACTED_KEYS and "image_redacted" not in allowed_views:
+                continue
+            if k in _DESCRIPTION_FULL_KEYS and "description_full" not in allowed_views:
+                continue
+            if k in _DESCRIPTION_SUMMARY_KEYS and "description_summary" not in allowed_views:
+                continue
+            # _AUDIT_KEYS / processing_warnings: always pass through
+            # so the receiver knows which model produced the
+            # description_summary they're allowed to see.
             out[k] = v
         return out
 
@@ -417,7 +445,14 @@ def marketplace_claim(body: dict, request: _Request) -> dict:
     data_user_attrs = body.get("data_user_attrs")
     if isinstance(data_user_attrs, dict) and data_user_attrs:
         from publisher.app.ssi.trust_score import evaluate_from_claims
-        evaluation = evaluate_from_claims(data_user_attrs)
+        # Stage T (VLM extension): when --profile vlm is on the
+        # marketplace claim mints a 4-tier allowed_views (full / access
+        # / summary / denied) that the /platform/data projector then
+        # uses. Off, the legacy 3-tier mapping is unchanged so existing
+        # tests keep their assertions valid.
+        evaluation = evaluate_from_claims(
+            data_user_attrs, vlm_profile=settings.vlm_enabled
+        )
         allowed_views = list(evaluation.allowed_views)
         trust_score = evaluation.trust_score
         access_level = evaluation.access_level

--- a/publisher/app/pipeline.py
+++ b/publisher/app/pipeline.py
@@ -10,7 +10,9 @@ from audit.repository import SQLiteAuditRepository
 from policy.engine import PolicyEngine
 from policy.store import ConsentStore
 from schemas.models import normalize
+from publisher.app.image_redactor import ImageRedactor, RedactionError
 from publisher.app.platform_client import PlatformClient
+from publisher.app.vlm_client import VLMClient, VLMError
 
 
 logger = logging.getLogger(__name__)
@@ -25,6 +27,8 @@ class MessageProcessor:
         policy_engine: PolicyEngine,
         audit_repo: SQLiteAuditRepository,
         platform_client: PlatformClient,
+        vlm_client: VLMClient | None = None,
+        image_redactor: ImageRedactor | None = None,
     ) -> None:
         self.publisher_id = publisher_id
         self.default_purpose = default_purpose
@@ -32,6 +36,11 @@ class MessageProcessor:
         self.policy_engine = policy_engine
         self.audit_repo = audit_repo
         self.platform_client = platform_client
+        # Stage T (VLM extension): optional injectors. When both are
+        # None the pipeline runs exactly the legacy path -- existing
+        # tier projection / pipeline tests must not regress.
+        self.vlm_client = vlm_client
+        self.image_redactor = image_redactor
 
     def process_message(self, topic: str, payload: dict, purpose: str | None = None) -> dict:
         normalized = normalize(topic, payload)
@@ -100,6 +109,49 @@ class MessageProcessor:
             inner = payload.get("data")
             if isinstance(inner, dict) and _media_key in inner:
                 envelope.setdefault(_media_key, inner[_media_key])
+
+        # Stage T (VLM extension): when injectors are configured, derive
+        # description_full / description_summary / image_url_redacted
+        # from the raw image and attach them to the envelope. Both
+        # injectors fail-soft: a failure produces a row that's still
+        # publishable (legacy keys remain), with a processing_warnings
+        # entry letting receivers know what was skipped. The
+        # /platform/data tier projector decides which derived keys are
+        # visible per tier.
+        warnings: list[str] = []
+        source_image_url = envelope.get("image_url")
+        source_video_url = envelope.get("video_url")
+        # Pick the source the VLM operates on. MVP: image only -- video
+        # frame extraction is future work, see spec "Future work".
+        vlm_source_url = source_image_url
+        vlm_source_ct = (
+            "image/jpeg" if source_image_url else
+            ("video/mp4" if source_video_url else "")
+        )
+        if self.vlm_client is not None and vlm_source_url:
+            try:
+                derived = self.vlm_client.describe(
+                    image_url=vlm_source_url,
+                    content_type=vlm_source_ct,
+                )
+            except VLMError as exc:
+                logger.warning("vlm describe failed: %s", exc)
+                warnings.append("vlm_unavailable")
+            else:
+                envelope.update(derived)
+        if self.image_redactor is not None and source_image_url:
+            try:
+                redacted = self.image_redactor.blur_pii(
+                    image_url=source_image_url,
+                    content_type=vlm_source_ct or "image/jpeg",
+                )
+            except RedactionError as exc:
+                logger.warning("image redaction failed: %s", exc)
+                warnings.append("redaction_unavailable")
+            else:
+                envelope.update(redacted)
+        if warnings:
+            envelope["processing_warnings"] = warnings
 
         try:
             self.platform_client.send(envelope)

--- a/publisher/app/ssi/trust_score.py
+++ b/publisher/app/ssi/trust_score.py
@@ -6,12 +6,29 @@ a trust score (0-100) and maps it to one of three access levels:
 so the publisher can drive the same evaluation off-chain (and stay in
 sync with the on-chain verifier when Stage 8d / ZK gets wired in).
 
-Stage T (case α) maps the access level to `allowed_views`:
+Stage T (case α, legacy 3-tier projection):
     full   -> ["event", "image", "video"]
     access -> ["event", "image"]
     denied -> []
 
+Stage T (VLM extension, 4-tier projection — opt-in via `vlm_profile=True`):
+    full    -> ["event", "image", "video",
+                "image_redacted",
+                "description_full", "description_summary"]
+    access  -> ["event",
+                "image_redacted",
+                "description_full", "description_summary"]
+    summary -> ["event", "description_summary"]
+    denied  -> []
+
+The legacy 3-tier projection is kept verbatim when `vlm_profile=False`
+so flipping the publisher's `--profile vlm` switch is the only thing
+that changes behaviour. Tests for the legacy path keep passing
+unchanged.
+
 Keep the scoring constants in lock-step with `DataUserVerifier.sol`.
+See ``docs/hands-on/data-user-vc-tiered-spec.md`` "Tier extension:
+semantic-level redaction (VLM)" for the schema contract.
 """
 from __future__ import annotations
 
@@ -21,7 +38,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class TrustEvaluation:
     trust_score: int
-    access_level: str  # "full" | "access" | "denied"
+    access_level: str  # "full" | "access" | "summary" | "denied"
     allowed_views: list[str]
 
 
@@ -41,6 +58,11 @@ _PURPOSE_SCORES = {
     "RESEARCH": 15,
 }
 
+# Score band that triggers the new `summary` tier when the VLM
+# profile is on. Below this band the claim is still rejected outright;
+# above this band the legacy `access` tier kicks in unchanged.
+_SUMMARY_TIER_FLOOR = 50
+
 
 def _entity_score(entity_type: str) -> int:
     return _ENTITY_SCORES.get(entity_type.upper(), 5)
@@ -50,11 +72,37 @@ def _purpose_score(purpose: str) -> int:
     return _PURPOSE_SCORES.get(purpose.upper(), 5)
 
 
-def _level_to_views(access_level: str) -> list[str]:
+def _level_to_views_legacy(access_level: str) -> list[str]:
     if access_level == "full":
         return ["event", "image", "video"]
     if access_level == "access":
         return ["event", "image"]
+    return []
+
+
+def _level_to_views_vlm(access_level: str) -> list[str]:
+    """Updated mapping when `--profile vlm` is on. Raw image/video keys
+    narrow to Tier 3 only; Tier 2 swaps `image` for `image_redacted`
+    and gains both description keys; Tier 1 (the new `summary` tier)
+    only ships the redacted summary text."""
+    if access_level == "full":
+        return [
+            "event",
+            "image",
+            "video",
+            "image_redacted",
+            "description_full",
+            "description_summary",
+        ]
+    if access_level == "access":
+        return [
+            "event",
+            "image_redacted",
+            "description_full",
+            "description_summary",
+        ]
+    if access_level == "summary":
+        return ["event", "description_summary"]
     return []
 
 
@@ -65,8 +113,20 @@ def evaluate(
     legal_compliance: bool,
     data_handling_policy: str,
     misuse_record: bool,
+    vlm_profile: bool = False,
 ) -> TrustEvaluation:
-    """Mirror of DataUserVerifier.sol: verifyUserAccess()."""
+    """Mirror of DataUserVerifier.sol: verifyUserAccess().
+
+    The trust score is profile-independent (the 5-attribute weight
+    table is shared with the on-chain verifier, so flipping the
+    publisher flag must not move the number).
+
+    `vlm_profile` only changes the `score -> access_level` cutoff (a
+    new `summary` band appears between `access` and `denied`) and the
+    `access_level -> allowed_views` mapping (new keys appear). When
+    `vlm_profile=False` the function returns exactly what the original
+    Stage T (case α) version did.
+    """
     score = _entity_score(entity_type) + _purpose_score(purpose)
     if legal_compliance:
         score += 15
@@ -81,17 +141,20 @@ def evaluate(
         access = "full"
     elif score >= 60:
         access = "access"
+    elif vlm_profile and score >= _SUMMARY_TIER_FLOOR:
+        access = "summary"
     else:
         access = "denied"
 
+    views = _level_to_views_vlm(access) if vlm_profile else _level_to_views_legacy(access)
     return TrustEvaluation(
         trust_score=score,
         access_level=access,
-        allowed_views=_level_to_views(access),
+        allowed_views=views,
     )
 
 
-def evaluate_from_claims(claims: dict) -> TrustEvaluation:
+def evaluate_from_claims(claims: dict, *, vlm_profile: bool = False) -> TrustEvaluation:
     """Convenience: read the 5 attributes straight from a DataUserVC's
     decoded claims dict (the publisher applies this when a DataUserVC
     is presented as part of a marketplace claim)."""
@@ -101,4 +164,5 @@ def evaluate_from_claims(claims: dict) -> TrustEvaluation:
         legal_compliance=bool(claims.get("legalCompliance", False)),
         data_handling_policy=str(claims.get("dataHandlingPolicy") or ""),
         misuse_record=bool(claims.get("misuseRecord", False)),
+        vlm_profile=vlm_profile,
     )

--- a/publisher/app/vlm_client.py
+++ b/publisher/app/vlm_client.py
@@ -1,0 +1,115 @@
+"""VLM client for the Stage T semantic-tier extension.
+
+Backends:
+
+* ``stub`` -- returns deterministic dummy strings keyed off the source
+  URL's sha256. Used by tests and by `--profile vlm` smoke tests when
+  no real model is connected. Never makes a network call.
+
+* ``ollama`` -- placeholder. Will POST to OLLAMA_API_URL with the
+  configured model (e.g. ``llava``). The actual HTTP wiring lands in
+  the next PR (Δ3) so this skeleton can ship without dragging Ollama
+  into the test environment. Today it raises ``VLMNotImplemented``.
+
+The pipeline calls ``VLMClient.describe(image_url, content_type)`` and
+expects either a dict with the four contract keys or a ``VLMError``
+subclass. Anything else is a programming bug; never silently fall back
+to a placeholder description because that bypasses the
+``processing_warnings`` channel that lets receivers know they're
+seeing a degraded result.
+
+See ``docs/hands-on/data-user-vc-tiered-spec.md`` "Tier extension:
+semantic-level redaction (VLM)" for the schema contract this module
+implements.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import datetime, timezone
+
+
+logger = logging.getLogger(__name__)
+
+
+class VLMError(Exception):
+    """Base class for any VLM call failure. Pipeline catches this and
+    marks the row with `processing_warnings: ["vlm_unavailable"]`."""
+
+
+class VLMNotImplemented(VLMError):
+    """Backend recognised but not wired in yet (e.g. ollama in Δ2)."""
+
+
+class VLMUnknownBackend(VLMError):
+    """``settings.vlm_backend`` doesn't match a known backend name."""
+
+
+def _stub_descriptions(image_url: str, content_type: str) -> tuple[str, str]:
+    """Deterministic dummy strings keyed off the source URL's sha256.
+
+    Tests rely on this being stable: the same input always produces the
+    same output, so projection assertions don't need to mock anything.
+
+    The strings are obviously synthetic ("[stub] ..." prefix) so a
+    receiver who somehow gets them in production immediately knows the
+    publisher is mis-configured.
+    """
+    sha = hashlib.sha256(image_url.encode("utf-8")).hexdigest()[:8]
+    full = (
+        f"[stub VLM:{sha}] A person in a blue jacket is dropping a plastic "
+        f"bottle near the park entrance. Source content-type: {content_type}."
+    )
+    summary = (
+        f"[stub VLM:{sha}] An adult dropped a piece of litter near a public "
+        f"location. Source content-type: {content_type}."
+    )
+    return full, summary
+
+
+class VLMClient:
+    """Thin client that turns an image URL into description_full +
+    description_summary plus audit metadata.
+
+    Construct via ``VLMClient.from_settings(settings)``; pass through
+    `None` when the backend is empty so callers can branch on
+    ``if vlm_client is not None`` without sprinkling settings checks.
+    """
+
+    def __init__(self, *, backend: str, api_url: str, model: str) -> None:
+        self.backend = backend
+        self.api_url = api_url
+        self.model = model
+
+    @classmethod
+    def from_settings(cls, settings) -> "VLMClient | None":
+        if not settings.vlm_backend:
+            return None
+        return cls(
+            backend=settings.vlm_backend,
+            api_url=settings.vlm_api_url,
+            model=settings.vlm_model,
+        )
+
+    def describe(self, *, image_url: str, content_type: str) -> dict:
+        """Return ``{description_full, description_summary,
+        description_model, description_generated_at}``.
+
+        Raises ``VLMError`` on any backend failure -- callers catch and
+        emit ``processing_warnings: ["vlm_unavailable"]``.
+        """
+        if self.backend == "stub":
+            full, summary = _stub_descriptions(image_url, content_type)
+            return {
+                "description_full": full,
+                "description_summary": summary,
+                "description_model": "stub-vlm/v0",
+                "description_generated_at": datetime.now(timezone.utc).isoformat(),
+            }
+        if self.backend == "ollama":
+            raise VLMNotImplemented(
+                "ollama backend is wired in Δ3; configure VLM_BACKEND=stub for now"
+            )
+        raise VLMUnknownBackend(
+            f"unknown vlm backend {self.backend!r}; expected one of: stub, ollama"
+        )

--- a/tests/test_data_user_vc_tiered_vlm.py
+++ b/tests/test_data_user_vc_tiered_vlm.py
@@ -1,0 +1,427 @@
+"""Stage T (VLM extension, Δ2 skeleton) tests.
+
+Covers the four buckets called out in the spec:
+
+  1. `--profile vlm` off: existing tier projection regresses to nothing
+  2. stub VLM backend produces the expected description_* shape
+  3. Per-tier /platform/data projection matrix (full/access/summary/denied)
+  4. Degrade matrix when VLM call or redaction fails
+  5. processing_warnings propagation to the receiver
+
+The pipeline is built standalone with a Sink so we don't need to
+spin up the FastAPI app for every assertion (matches the pattern
+test_data_user_vc_tiered.py uses for processor-level tests).
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from publisher.app.image_redactor import (
+    ImageRedactor,
+    RedactionError,
+    RedactionUnknownBackend,
+)
+from publisher.app.pipeline import MessageProcessor
+from publisher.app.ssi.trust_score import evaluate, evaluate_from_claims
+from publisher.app.vlm_client import (
+    VLMClient,
+    VLMError,
+    VLMNotImplemented,
+    VLMUnknownBackend,
+)
+from policy.engine import PolicyEngine
+from policy.models import ConsentVC
+from policy.store import ConsentStore
+from audit.repository import SQLiteAuditRepository
+
+
+# ---------- (1) Trust score: profile-off keeps legacy 3-tier ----------
+
+
+def test_trust_score_profile_off_full():
+    """Tier 3 (full): unchanged shape under legacy projection."""
+    e = evaluate(
+        entity_type="GovernmentOrganization",
+        purpose="CrimeSearch",
+        legal_compliance=True,
+        data_handling_policy="ISO27001",
+        misuse_record=False,
+    )
+    assert e.access_level == "full"
+    assert e.allowed_views == ["event", "image", "video"]
+
+
+def test_trust_score_profile_off_access():
+    """Tier 2 (access): legacy mapping is image-with-no-video."""
+    e = evaluate(
+        entity_type="Enterprise",
+        purpose="Research",
+        legal_compliance=True,
+        data_handling_policy="ISO27001",
+        misuse_record=False,
+    )
+    assert e.access_level == "access"
+    assert e.allowed_views == ["event", "image"]
+
+
+def test_trust_score_profile_off_denied():
+    """Below 60 still denies (no `summary` tier without VLM profile)."""
+    e = evaluate(
+        entity_type="Enterprise",
+        purpose="Research",
+        legal_compliance=False,
+        data_handling_policy="Other",
+        misuse_record=True,
+    )
+    assert e.access_level == "denied"
+    assert e.allowed_views == []
+
+
+def test_trust_score_profile_off_no_summary_band():
+    """Profile-off MUST NOT introduce the summary tier even at scores
+    that would qualify for it under the VLM profile (50-59). Regression
+    guard: a careless refactor that leaks vlm_profile=True default
+    would silently widen what receivers see."""
+    # 25 (entity ENTERPRISE) + 5 (purpose unknown) + 0 + 0 + 10 = 40
+    e = evaluate(
+        entity_type="Enterprise",
+        purpose="unknown",
+        legal_compliance=False,
+        data_handling_policy="other",
+        misuse_record=False,
+    )
+    # That's 50, but score-band assertion below uses entity_score 20
+    # for enterprise -- so total = 20+5+0+0+10 = 35, which IS denied.
+    # Either way the test asserts: profile off NEVER returns summary.
+    assert e.access_level != "summary"
+
+
+# ---------- (2) Trust score: profile-on opens summary tier ----------
+
+
+def test_trust_score_profile_on_full_extends_views():
+    e = evaluate(
+        entity_type="GovernmentOrganization",
+        purpose="CrimeSearch",
+        legal_compliance=True,
+        data_handling_policy="ISO27001",
+        misuse_record=False,
+        vlm_profile=True,
+    )
+    assert e.access_level == "full"
+    assert "image" in e.allowed_views
+    assert "video" in e.allowed_views
+    assert "image_redacted" in e.allowed_views
+    assert "description_full" in e.allowed_views
+    assert "description_summary" in e.allowed_views
+
+
+def test_trust_score_profile_on_access_swaps_image_for_redacted():
+    e = evaluate(
+        entity_type="Enterprise",
+        purpose="Research",
+        legal_compliance=True,
+        data_handling_policy="ISO27001",
+        misuse_record=False,
+        vlm_profile=True,
+    )
+    assert e.access_level == "access"
+    # No raw image / video at access tier under VLM projection
+    assert "image" not in e.allowed_views
+    assert "video" not in e.allowed_views
+    # But the redacted image + both descriptions are visible
+    assert "image_redacted" in e.allowed_views
+    assert "description_full" in e.allowed_views
+    assert "description_summary" in e.allowed_views
+
+
+def test_trust_score_profile_on_summary_band_visible():
+    """A 50-59 score under VLM profile maps to summary, not denied."""
+    # entity ENTERPRISE (20) + purpose RESEARCH (15) + legal (15) + no_misuse (10) = 60
+    # That's exactly access -- need to drop one to 59. Easiest: misuse=true (-10).
+    # 20 + 15 + 15 + 0 - 10 = 40 -> still under 50 (denied).
+    # Try: enterprise + research + legal=False + ISO27001 + no_misuse:
+    # 20 + 15 + 0 + 15 + 10 = 60 -> access. Drop ISO: 20+15+0+0+10 = 45 (denied).
+    # The construction is sensitive. Use a synthetic call instead:
+    e = evaluate(
+        entity_type="Enterprise",
+        purpose="Research",
+        legal_compliance=True,  # +15
+        data_handling_policy="other",
+        misuse_record=False,  # +10
+        vlm_profile=True,
+    )
+    # 20 + 15 + 15 + 0 + 10 = 60 -> access (still). Try purpose=unknown:
+    e2 = evaluate(
+        entity_type="Enterprise",
+        purpose="unknown",
+        legal_compliance=True,  # +15
+        data_handling_policy="other",
+        misuse_record=False,  # +10
+        vlm_profile=True,
+    )
+    # 20 + 5 + 15 + 0 + 10 = 50 -> summary
+    assert e2.access_level == "summary", e2
+    assert e2.allowed_views == ["event", "description_summary"]
+
+
+def test_trust_score_profile_on_summary_collapses_to_denied_under_legacy():
+    """The same `score==50` claim that earns `summary` under the VLM
+    profile MUST still return `denied` under the legacy projection."""
+    legacy = evaluate(
+        entity_type="Enterprise",
+        purpose="unknown",
+        legal_compliance=True,
+        data_handling_policy="other",
+        misuse_record=False,
+    )
+    assert legacy.access_level == "denied"
+
+
+def test_evaluate_from_claims_passes_profile_through():
+    claims = {
+        "entityType": "Enterprise",
+        "purpose": "Research",
+        "legalCompliance": True,
+        "dataHandlingPolicy": "ISO27001",
+        "misuseRecord": False,
+    }
+    legacy = evaluate_from_claims(claims)
+    vlm = evaluate_from_claims(claims, vlm_profile=True)
+    assert legacy.access_level == "access"
+    assert vlm.access_level == "access"
+    # Same access level, different allowed_views (the VLM profile
+    # widens Tier 2's projection rather than re-tiering this row).
+    assert legacy.allowed_views == ["event", "image"]
+    assert vlm.allowed_views == [
+        "event",
+        "image_redacted",
+        "description_full",
+        "description_summary",
+    ]
+
+
+# ---------- (3) VLMClient stub backend produces the contract shape ----------
+
+
+def test_vlm_stub_returns_four_keys():
+    c = VLMClient(backend="stub", api_url="", model="stub-vlm/v0")
+    out = c.describe(
+        image_url="http://example/media/abc.jpg",
+        content_type="image/jpeg",
+    )
+    assert set(out.keys()) == {
+        "description_full",
+        "description_summary",
+        "description_model",
+        "description_generated_at",
+    }
+    assert "[stub VLM" in out["description_full"]
+    assert "[stub VLM" in out["description_summary"]
+    assert out["description_model"] == "stub-vlm/v0"
+
+
+def test_vlm_stub_is_deterministic():
+    """Same image_url -> same description hash. Lets tests assert on
+    the exact strings without mocking randomness."""
+    c = VLMClient(backend="stub", api_url="", model="stub-vlm/v0")
+    a = c.describe(image_url="http://example/media/x.jpg", content_type="image/jpeg")
+    b = c.describe(image_url="http://example/media/x.jpg", content_type="image/jpeg")
+    assert a["description_full"] == b["description_full"]
+    assert a["description_summary"] == b["description_summary"]
+
+
+def test_vlm_ollama_backend_is_not_yet_implemented():
+    c = VLMClient(backend="ollama", api_url="http://ollama:11434", model="llava")
+    with pytest.raises(VLMNotImplemented):
+        c.describe(image_url="http://example/x.jpg", content_type="image/jpeg")
+
+
+def test_vlm_unknown_backend_raises():
+    c = VLMClient(backend="bogus", api_url="", model="")
+    with pytest.raises(VLMUnknownBackend):
+        c.describe(image_url="http://example/x.jpg", content_type="image/jpeg")
+
+
+def test_vlm_from_settings_disabled_returns_none():
+    class _S:
+        vlm_backend = ""
+        vlm_api_url = ""
+        vlm_model = ""
+
+    assert VLMClient.from_settings(_S()) is None
+
+
+# ---------- (4) ImageRedactor stub passes a marker URL ----------
+
+
+def test_image_redactor_stub_marks_url():
+    r = ImageRedactor(backend="stub")
+    out = r.blur_pii(
+        image_url="http://example/media/abc.jpg",
+        content_type="image/jpeg",
+    )
+    assert "redacted=stub" in out["image_url_redacted"]
+    assert out["image_cid_redacted"] is None
+
+
+def test_image_redactor_video_is_not_implemented():
+    r = ImageRedactor(backend="stub")
+    with pytest.raises(RedactionError):
+        r.blur_pii(image_url="http://example/x.mp4", content_type="video/mp4")
+
+
+def test_image_redactor_unknown_backend_raises():
+    r = ImageRedactor(backend="bogus")
+    with pytest.raises(RedactionUnknownBackend):
+        r.blur_pii(image_url="http://example/x.jpg", content_type="image/jpeg")
+
+
+# ---------- (5) Pipeline integration: VLM + redactor wiring ----------
+
+
+def _build_processor(*, vlm_client=None, image_redactor=None):
+    """Build a MessageProcessor with seeded consent for
+    home/event/possible_littering. Returns (processor, sink) where
+    sink.last is the most recent envelope sent."""
+    td = tempfile.mkdtemp(prefix="vlm-test-")
+    cs = ConsentStore(os.path.join(td, "c.json"))
+    now = datetime.now(timezone.utc)
+    cs.upsert(
+        ConsentVC(
+            vc_id="c-vlm-test",
+            subject_did="did:example:provider",
+            dataset_id="home/event/possible_littering",
+            allowed_purposes=["community_cleaning"],
+            retention_days=14,
+            reshare_allowed=False,
+            valid_from=now - timedelta(days=1),
+            valid_to=now + timedelta(days=30),
+            signature="x",
+        )
+    )
+
+    captured: list[dict] = []
+
+    class _Sink:
+        def send(self, env: dict) -> None:
+            captured.append(env)
+
+    proc = MessageProcessor(
+        publisher_id="t",
+        default_purpose="community_cleaning",
+        consent_store=cs,
+        policy_engine=PolicyEngine(),
+        audit_repo=SQLiteAuditRepository(os.path.join(td, "a.db")),
+        platform_client=_Sink(),
+        vlm_client=vlm_client,
+        image_redactor=image_redactor,
+    )
+    return proc, captured
+
+
+def _publish(proc):
+    return proc.process_message(
+        "homeassistant/event/possible_littering",
+        {
+            "event_type": "possible_littering",
+            "ts": "2026-04-30T07:00:00Z",
+            "source": "iw3ip-provider-page",
+            "image_url": "http://publisher/media/abc.jpg",
+            "data": {},
+        },
+        "community_cleaning",
+    )
+
+
+def test_pipeline_no_injectors_keeps_legacy_envelope():
+    """Δ2 regression: when both injectors are None the envelope is
+    byte-for-byte identical to the pre-VLM behaviour. Description /
+    redacted keys MUST NOT appear and processing_warnings MUST NOT
+    leak in."""
+    proc, sent = _build_processor()
+    result = _publish(proc)
+    assert result["status"] == "allowed"
+    env = sent[0]
+    assert "description_full" not in env
+    assert "description_summary" not in env
+    assert "image_url_redacted" not in env
+    assert "image_cid_redacted" not in env
+    assert "processing_warnings" not in env
+
+
+def test_pipeline_stub_backends_attach_all_keys():
+    proc, sent = _build_processor(
+        vlm_client=VLMClient(backend="stub", api_url="", model="stub-vlm/v0"),
+        image_redactor=ImageRedactor(backend="stub"),
+    )
+    _publish(proc)
+    env = sent[0]
+    assert "[stub VLM" in env["description_full"]
+    assert "[stub VLM" in env["description_summary"]
+    assert env["description_model"] == "stub-vlm/v0"
+    assert "redacted=stub" in env["image_url_redacted"]
+    # Both injectors succeeded -> no warnings entry at all.
+    assert "processing_warnings" not in env
+
+
+def test_pipeline_vlm_failure_emits_warning_but_keeps_redacted():
+    """VLM down + redactor up: row ships without descriptions but the
+    redacted image is still there, plus processing_warnings flags
+    `vlm_unavailable` so receivers know what they're missing."""
+
+    class _BrokenVLM:
+        def describe(self, **_kwargs):
+            raise VLMError("simulated outage")
+
+    proc, sent = _build_processor(
+        vlm_client=_BrokenVLM(),
+        image_redactor=ImageRedactor(backend="stub"),
+    )
+    _publish(proc)
+    env = sent[0]
+    assert "description_full" not in env
+    assert "description_summary" not in env
+    assert "redacted=stub" in env["image_url_redacted"]
+    assert env["processing_warnings"] == ["vlm_unavailable"]
+
+
+def test_pipeline_redaction_failure_emits_warning_but_keeps_descriptions():
+    class _BrokenRedactor:
+        def blur_pii(self, **_kwargs):
+            raise RedactionError("simulated outage")
+
+    proc, sent = _build_processor(
+        vlm_client=VLMClient(backend="stub", api_url="", model="stub-vlm/v0"),
+        image_redactor=_BrokenRedactor(),
+    )
+    _publish(proc)
+    env = sent[0]
+    assert "[stub VLM" in env["description_full"]
+    assert "image_url_redacted" not in env
+    assert env["processing_warnings"] == ["redaction_unavailable"]
+
+
+def test_pipeline_both_fail_emits_both_warnings_and_raw_keys_remain():
+    class _BrokenVLM:
+        def describe(self, **_kwargs):
+            raise VLMError("vlm down")
+
+    class _BrokenRedactor:
+        def blur_pii(self, **_kwargs):
+            raise RedactionError("blur down")
+
+    proc, sent = _build_processor(
+        vlm_client=_BrokenVLM(),
+        image_redactor=_BrokenRedactor(),
+    )
+    _publish(proc)
+    env = sent[0]
+    assert env["processing_warnings"] == ["vlm_unavailable", "redaction_unavailable"]
+    # Raw key MUST still ship -- the publisher is NOT supposed to
+    # silently drop content when the derivatives are down.
+    assert env["image_url"] == "http://publisher/media/abc.jpg"


### PR DESCRIPTION
## Summary
Δ2 of the 4-step rollout defined in [iw3ip.github.io#30](https://github.com/ertlnagoya/iw3ip.github.io/pull/30). Implements the architecture for **semantic-level tier projection** (description_full / description_summary / image_redacted) with **stub backends only** so the contract lands without Ollama / OpenCV in the test path.

## Backwards compatibility
Both `VLM_BACKEND` and `IMAGE_REDACTION_BACKEND` default to `""`, which keeps the existing 3-tier projection byte-for-byte unchanged.

- 129 pre-existing tests pass **unmodified**
- New regression guard `test_pipeline_no_injectors_keeps_legacy_envelope` asserts the envelope is identical to the pre-VLM behaviour when injectors are None
- `--profile vlm` is opt-in (`docker compose --profile vlm up`) and the placeholder service exists so the smoke path works with `VLM_BACKEND=stub`

## What ships
- `publisher/app/vlm_client.py` — VLMClient (stub backend deterministic, ollama placeholder for Δ3)
- `publisher/app/image_redactor.py` — ImageRedactor (stub backend marks URL, opencv placeholder for Δ3)
- `publisher/app/ssi/trust_score.py` — `evaluate(..., vlm_profile=False)` adds `summary` band (50≤score<60) and the new `_level_to_views_vlm` mapping when on
- `publisher/app/pipeline.py` — MessageProcessor takes optional injectors; failures emit `processing_warnings[]`
- `publisher/app/main.py` — `/platform/data` projector handles new keys (`image_url_redacted`, `description_full`, `description_summary`); audit keys pass through always; `/marketplace/claim` threads `vlm_profile` per `settings.vlm_enabled`
- `publisher/app/config.py` — 4 new env vars + `vlm_enabled` property
- `infra/docker-compose.yml` — `--profile vlm` placeholder service + 4 new env passthroughs
- `tests/test_data_user_vc_tiered_vlm.py` — 22 cases covering trust score, stub backends, pipeline integration, and degrade matrix

## Tier projection (when VLM profile is on)
```
full    -> [event, image, video, image_redacted, description_full, description_summary]
access  -> [event, image_redacted, description_full, description_summary]
summary -> [event, description_summary]              ← NEW band, 50≤score<60
denied  -> []
```

## Test plan
- [x] `pytest tests/test_data_user_vc_tiered_vlm.py` — 22/22 pass
- [x] `pytest tests/` (full suite) — 151/151 pass, 0 regressions
- [ ] Real-device smoke (Δ3): `docker compose --profile vlm up` with `VLM_BACKEND=stub` produces the new keys end-to-end via `/provider/publish`

## Out of scope (Δ3+)
- Real OpenCV face-blur backend
- Real Ollama HTTP wiring + a `vlm` service that loads `llava`
- `/viewer` rendering processing_warnings to operators
- Hands-on `§12` walkthrough (Δ4)

## Out of scope (research TODOs, recorded in spec)
- Redaction-leak detection (NER diff + PII dictionary)
- sha256-keyed description cache
- Per-tier VLM call cost gating

🤖 Generated with [Claude Code](https://claude.com/claude-code)
