### PR TITLE
fix(vlm): bump default Ollama timeout 60s → 180s + VLM_TIMEOUT_SEC env

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -56,6 +56,11 @@ services:
       # the host) by setting VLM_API_URL in the shell before `up`.
       VLM_API_URL: ${VLM_API_URL:-http://vlm:11434}
       VLM_MODEL: ${VLM_MODEL:-llava}
+      # Per-call timeout for /api/generate. CPU-only LLaVA-7B on a
+      # 1024x1024 image needs 60-150s; describe() does it twice
+      # (full + summary). Default 180s per call ≈ 6 min worst case
+      # before degradation. Lower for GPU setups.
+      VLM_TIMEOUT_SEC: ${VLM_TIMEOUT_SEC:-180}
       IMAGE_REDACTION_BACKEND: ${IMAGE_REDACTION_BACKEND:-}
       SSI_ISSUER_BASE_URL: ${SSI_ISSUER_BASE_URL:-http://publisher:8080}
       SSI_ISSUER_KEY_PATH: /data/issuer_key.jwk.json

--- a/publisher/app/vlm_client.py
+++ b/publisher/app/vlm_client.py
@@ -59,7 +59,26 @@ _PROMPT_SUMMARY = (
 # timeout generous so the first-publish UX isn't a misleading
 # `vlm_unavailable` warning. The pipeline catches the timeout and
 # degrades gracefully if it does fire.
-_OLLAMA_TIMEOUT_SEC = 60.0
+#
+# Real-device finding (2026-04-30): a CPU-only LLaVA-7B inference on
+# a 1024x1024 image takes 60-150s for a single /api/generate call.
+# Two stages (full + summary) means the full describe() needs ~3-5
+# minutes worst case. Default of 180s per call (so describe() can
+# spend ~6 min before we degrade) covers most CPU setups; users with
+# GPU acceleration or smaller models can lower it via env. Override
+# with VLM_TIMEOUT_SEC if you have specific latency targets.
+_OLLAMA_TIMEOUT_SEC_DEFAULT = 180.0
+
+
+def _ollama_timeout() -> float:
+    import os
+    raw = os.environ.get("VLM_TIMEOUT_SEC", "").strip()
+    if not raw:
+        return _OLLAMA_TIMEOUT_SEC_DEFAULT
+    try:
+        return float(raw)
+    except ValueError:
+        return _OLLAMA_TIMEOUT_SEC_DEFAULT
 
 
 class VLMError(Exception):
@@ -122,7 +141,7 @@ def _ollama_generate(
         "stream": False,
     }
     try:
-        with httpx.Client(timeout=_OLLAMA_TIMEOUT_SEC) as client:
+        with httpx.Client(timeout=_ollama_timeout()) as client:
             r = client.post(endpoint, json=body)
             r.raise_for_status()
             payload = r.json()


### PR DESCRIPTION
## Summary
Real-device finding from γ validation: CPU-only LLaVA-7B on 1024×1024 takes 60-150s per `/api/generate`, so the Δ3 default of 60s reliably timed out on the first stage. Bumps default to 180s/call and exposes `VLM_TIMEOUT_SEC` env var.

## Found by
γ pass right after Δ3 (#44) merged: synthetic-face e2e timed out at exactly 60s on both attempts. OpenCV path worked end-to-end on the same call (detected=1, redacted upload succeeded), so the bug was specifically in the VLM timeout budget.

## Test plan
- [x] `pytest tests/test_data_user_vc_tiered_vlm.py` — 26/26 pass
- [ ] Real-device retry: `docker compose --profile vlm up`, publish synthetic face → both `description_full` and `description_summary` should now appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
