### PR TITLE
docs(provider): correct Safari MP4-fallback comment in pickRecorderMime

### DIFF
--- a/publisher/app/provider_routes.py
+++ b/publisher/app/provider_routes.py
@@ -593,7 +593,15 @@ _PROVIDER_HTML = r"""<!DOCTYPE html>
     const recStatus = document.getElementById("recStatus");
 
     function pickRecorderMime() {
-      // Prefer VP9 then VP8 (Chromium/Firefox), fall back to MP4 (Safari 14.1+).
+      // Prefer VP9 then VP8. Real-device matrix on macOS (verified
+      // 2026-04-30 in iw3ip.github.io PR #29 §11.8 B/C/D):
+      //   Chrome 147:    all 4 supported -> picks VP9
+      //   Safari 17+:    all 4 supported -> picks VP9 (modern Safari
+      //                  has WebM/VP9 native support; the long-standing
+      //                  "Safari falls back to MP4" assumption only
+      //                  applies to Safari 16 and earlier)
+      //   Firefox 139:   only VP8 / webm -> picks VP8
+      // The MP4 entry stays for Safari 14.1-16 backwards compat.
       const candidates = [
         "video/webm;codecs=vp9,opus",
         "video/webm;codecs=vp8,opus",


### PR DESCRIPTION
## Summary
The `pickRecorderMime()` JS comment said "fall back to MP4 (Safari 14.1+)" — that's outdated. Real-device validation in [iw3ip.github.io#29 §11.8](https://github.com/ertlnagoya/iw3ip.github.io/pull/29) found that **macOS Safari 17+ supports WebM/VP9 natively**, so the preference list `[vp9, vp8, webm, mp4]` picks VP9 on modern Safari — not MP4.

## Cross-browser matrix observed 2026-04-30
- Chrome 147: all 4 supported → picks **VP9**
- Safari 17+: all 4 supported → picks **VP9** (not MP4)
- Firefox 139: only VP8 / webm → picks **VP8**

## What changes
Only the comment. The candidate list ordering is correct; MP4 stays for Safari 14.1–16 backcompat.

## Test plan
- [x] `pytest tests/test_ssi_seller_token.py` — 23/23 pass (no functional change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
