### PR TITLE
feat(viewer): render VLM-extension keys + processing_warnings

### DIFF
--- a/publisher/app/viewer_routes.py
+++ b/publisher/app/viewer_routes.py
@@ -120,6 +120,32 @@ _VIEWER_HTML = r"""<!DOCTYPE html>
     .badge.tier-3 { background: rgba(76, 175, 80, 0.18); color: #2e7d32; }
     .badge.tier-2 { background: rgba(255, 152, 0, 0.20); color: #c77800; }
     .badge.tier-1 { background: rgba(158, 158, 158, 0.25); color: #555; }
+    /* Stage T (VLM extension): semantic-tier styling. */
+    .badge.tier-summary { background: rgba(96, 125, 139, 0.20); color: #455a64; }
+    .description {
+      background: #f5f5f5; padding: 0.75rem 1rem; border-radius: 6px;
+      border-left: 3px solid #2e7d32; margin-block: 0.5rem;
+    }
+    .description.summary { border-left-color: #c77800; }
+    .description-label {
+      font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.04em;
+      color: #666; margin-bottom: 0.3rem;
+    }
+    .warnings {
+      padding: 0.75rem 1rem; background: #fff7e6; border-radius: 6px;
+      border-left: 3px solid #f57c00; color: #8a6d3b; margin-block: 0.5rem;
+      font-size: 0.85rem;
+    }
+    .warnings code {
+      background: rgba(245, 124, 0, 0.15); padding: 1px 6px; border-radius: 4px;
+      margin-inline: 2px; font-family: ui-monospace, Menlo, monospace; font-size: 0.78rem;
+    }
+    .redacted-badge {
+      font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em;
+      background: rgba(96, 125, 139, 0.20); color: #455a64;
+      padding: 1px 6px; border-radius: 4px; margin-left: 6px;
+      vertical-align: middle;
+    }
     section { margin-block: 1rem; }
     .media { display: grid; gap: 0.75rem; }
     .media img, .media video {
@@ -201,10 +227,18 @@ _VIEWER_HTML = r"""<!DOCTYPE html>
         const body = await r.json();
         const tier = (body.allowed_views || []).join("+") || "—";
         document.getElementById("tier").textContent = `tier: ${tier}`;
-        document.getElementById("tier").classList.add(
-          body.allowed_views?.includes("video") ? "tier-3" :
-          body.allowed_views?.includes("image") ? "tier-2" : "tier-1"
-        );
+        // Stage T (VLM extension): the badge picks up the new semantic
+        // tiers. With raw video -> tier-3, with raw image -> tier-2,
+        // with image_redacted (no raw image) -> tier-2 still (visual
+        // tier 2 either way), with description_summary only and no
+        // images -> the new "summary" tier; otherwise tier-1 (event-only).
+        const v = body.allowed_views || [];
+        const tierClass =
+          v.includes("video") ? "tier-3" :
+          v.includes("image") || v.includes("image_redacted") ? "tier-2" :
+          v.includes("description_summary") ? "tier-summary" :
+          "tier-1";
+        document.getElementById("tier").classList.add(tierClass);
         document.getElementById("meta").textContent =
           `${DS} • ${body.count} row${body.count === 1 ? "" : "s"}` +
           (body.seller_did ? ` • seller=${body.seller_did}` : "");
@@ -228,26 +262,90 @@ _VIEWER_HTML = r"""<!DOCTYPE html>
       const card = el("section");
       const media = el("div", { class: "media" });
 
-      // image_url is the publisher-hosted URL (Stage T case B). When
-      // the producer used IPFS too (case C) image_cid + ipfs_gateway_url
-      // also exist; we just prefer image_url for the inline render
-      // because it's guaranteed-reachable on the buyer's network.
+      // Stage T media projection. Order of preference for the inline
+      // <img> rendering:
+      //   row.image_url          (Tier 3 raw, case B/C)
+      //   row.image_url_redacted (Tier 2+ blurred, VLM extension)
+      // We render whichever is present. Only one shows up at a time
+      // because /platform/data drops keys per allowed_views.
       if (row.image_url) {
         media.appendChild(el("img", { src: row.image_url, alt: "image" }));
+      } else if (row.image_url_redacted) {
+        const wrap = el("div");
+        const img = el("img", { src: row.image_url_redacted, alt: "redacted image" });
+        wrap.appendChild(img);
+        const tag = el("span", { class: "redacted-badge", text: "🔒 face/PII blurred" });
+        wrap.appendChild(tag);
+        media.appendChild(wrap);
       }
       if (row.video_url) {
         media.appendChild(el("video", { src: row.video_url, controls: "" }));
       }
       if (media.children.length) card.appendChild(media);
 
+      // Stage T (VLM extension): description_full / description_summary
+      // appear at Tier 2+ / Tier 1+ respectively. Show both when both
+      // are visible (Tier 2/3) so the receiver sees the contrast
+      // between named-entity detail and PII-scrubbed summary.
+      if (row.description_full) {
+        const box = el("div", { class: "description" });
+        box.appendChild(el("div", { class: "description-label", text: "VLM detailed (full)" }));
+        box.appendChild(el("p", { text: row.description_full }));
+        card.appendChild(box);
+      }
+      if (row.description_summary) {
+        const box = el("div", { class: "description summary" });
+        box.appendChild(el("div", { class: "description-label", text: "VLM summary (PII-redacted)" }));
+        box.appendChild(el("p", { text: row.description_summary }));
+        card.appendChild(box);
+      }
+
+      // Stage T (VLM extension): processing_warnings tells the receiver
+      // which derivative steps were degraded. The meaningful keys today
+      // are vlm_unavailable + redaction_unavailable; we render any
+      // future warnings transparently so the contract is forward-
+      // compatible.
+      if (Array.isArray(row.processing_warnings) && row.processing_warnings.length) {
+        const w = el("div", { class: "warnings" });
+        const intro = el("span", {
+          text: "⚠ 一部の派生データが省略されました: ",
+        });
+        w.appendChild(intro);
+        row.processing_warnings.forEach((name, i) => {
+          if (i > 0) w.appendChild(document.createTextNode(" "));
+          w.appendChild(el("code", { text: name }));
+        });
+        card.appendChild(w);
+      }
+
       // Surface the IPFS CID if present so the viewer doubles as
-      // proof-of-content-addressing.
+      // proof-of-content-addressing. Show the redacted variant too
+      // so receivers can audit which content-addressed bytes they
+      // actually got.
       if (row.image_cid) {
         card.appendChild(el("p", { class: "meta" },
           "IPFS CID: ",
           el("a", { class: "cid", href: `${ORIGIN}/ipfs/${row.image_cid}` },
             row.image_cid)
         ));
+      }
+      if (row.image_cid_redacted) {
+        card.appendChild(el("p", { class: "meta" },
+          "IPFS CID (redacted): ",
+          el("a", { class: "cid", href: `${ORIGIN}/ipfs/${row.image_cid_redacted}` },
+            row.image_cid_redacted)
+        ));
+      }
+
+      // Surface VLM model + generation time so the receiver knows
+      // exactly which inference produced description_*.
+      if (row.description_model) {
+        const meta = el("p", { class: "meta" });
+        meta.textContent = `VLM: ${row.description_model}`;
+        if (row.description_generated_at) {
+          meta.textContent += ` • generated ${row.description_generated_at}`;
+        }
+        card.appendChild(meta);
       }
 
       const ts = row.payload?.ts || row.ts || "";

--- a/tests/test_data_user_vc_tiered.py
+++ b/tests/test_data_user_vc_tiered.py
@@ -1069,6 +1069,31 @@ def test_viewer_page_requires_query_params(client):
     assert r.status_code == 422
 
 
+def test_viewer_page_wires_vlm_extension_keys(client):
+    """Stage T (VLM extension): /viewer's page-side JS must reference
+    the new keys it's expected to render: image_url_redacted,
+    image_cid_redacted, description_full, description_summary,
+    description_model, description_generated_at, processing_warnings.
+    A regression here means receivers won't see the redacted image or
+    the degrade warnings the spec promises."""
+    tc, _ = client
+    r = tc.get("/viewer", params={"vt": "fake-token", "ds": "home/env/temperature"})
+    body = r.text
+    # New media key (Tier 2+)
+    assert "image_url_redacted" in body
+    assert "image_cid_redacted" in body
+    # Description text fields
+    assert "description_full" in body
+    assert "description_summary" in body
+    # Audit fields (always passed through)
+    assert "description_model" in body
+    assert "description_generated_at" in body
+    # Degrade signal
+    assert "processing_warnings" in body
+    # Tier badge classification logic gains the new "summary" branch
+    assert "tier-summary" in body
+
+
 def test_buyer_start_page_renders_html(client):
     tc, _ = client
     r = tc.get("/buyer/start", params={"ds": "home/event/possible_littering"})


### PR DESCRIPTION
## Summary
Closes the "/viewer prefers raw keys" gap noted in [iw3ip.github.io#31 §12.8](https://github.com/ertlnagoya/iw3ip.github.io/pull/31). The receiver now sees the full Stage T VLM tier projection:

- **Tier 3**: raw `image_url` + `video_url` + descriptions (existing)
- **Tier 2**: `image_url_redacted` (with 🔒 face/PII blurred badge) + both descriptions
- **Tier 1 summary**: `description_summary` only — new `tier-summary` chip styling
- **Any tier**: `processing_warnings[]` rendered per-row as a forward-compatible warning banner

## Visible affordances
- 🔒 badge next to redacted images so receivers don't mistake them for originals
- Side-by-side description panels (green = `_full`, orange = `_summary`) so the named-entity vs PII-scrubbed contrast is obvious at Tier 2/3
- VLM model + generation timestamp shown in meta text for audit
- Redacted IPFS CID surfaced separately when present

## Test plan
- [x] `pytest tests/` — 159/159 pass (1 new)
- [ ] Real-device: `--profile vlm` + Tier 3 ViewerToken → all 5 keys render; toggle VLM-down to verify warnings banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
