### PR TITLE
chore(compose): pass SEMANTIC_ANALYZER_BACKEND through to publisher

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -62,6 +62,12 @@ services:
       # before degradation. Lower for GPU setups.
       VLM_TIMEOUT_SEC: ${VLM_TIMEOUT_SEC:-180}
       IMAGE_REDACTION_BACKEND: ${IMAGE_REDACTION_BACKEND:-}
+      # Stage T+ (semantic-tier pipeline). Backends:
+      #   ""     -> mock (deterministic stub; default)
+      #   "stub" -> alias of mock
+      #   "vision" -> OpenCV Haar + MSER
+      SEMANTIC_ANALYZER_BACKEND: ${SEMANTIC_ANALYZER_BACKEND:-}
+      SEMANTIC_ALLOW_UNKNOWN_AT_HIGH: ${SEMANTIC_ALLOW_UNKNOWN_AT_HIGH:-false}
       SSI_ISSUER_BASE_URL: ${SSI_ISSUER_BASE_URL:-http://publisher:8080}
       SSI_ISSUER_KEY_PATH: /data/issuer_key.jwk.json
       SSI_PEX_SIDECAR_URL: http://verifier-sidecar:7000


### PR DESCRIPTION
Tiny one-liner. Mirror the existing VLM_* / IMAGE_REDACTION_BACKEND env passthrough pattern so `SEMANTIC_ANALYZER_BACKEND=vision docker compose up` actually flips the analyzer.